### PR TITLE
Implement backend logic to manage client profile edit

### DIFF
--- a/app/src/androidTest/java/com/android/solvit/seeker/ui/profile/EditSeekerProfileTest.kt
+++ b/app/src/androidTest/java/com/android/solvit/seeker/ui/profile/EditSeekerProfileTest.kt
@@ -1,0 +1,74 @@
+package com.android.solvit.seeker.ui.profile
+
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.navigation.NavController
+import com.android.solvit.seeker.model.profile.SeekerProfile
+import com.android.solvit.seeker.model.profile.SeekerProfileViewModel
+import com.android.solvit.seeker.model.profile.UserRepository
+import com.android.solvit.shared.model.authentication.AuthRepository
+import com.android.solvit.shared.model.authentication.AuthViewModel
+import com.android.solvit.shared.ui.navigation.NavigationActions
+import junit.framework.TestCase.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+
+class EditSeekerProfileTest {
+  private lateinit var userRepository: UserRepository
+  private lateinit var navController: NavController
+  private lateinit var authRepository: AuthRepository
+  private lateinit var seekerProfileViewModel: SeekerProfileViewModel
+  private lateinit var navigationActions: NavigationActions
+  private lateinit var authViewModel: AuthViewModel
+
+  private val testSeekerProfile =
+      SeekerProfile(
+          uid = "12345",
+          name = "John Doe",
+          username = "johndoe",
+          email = "john.doe@example.com",
+          phone = "+1234567890",
+          address = "Chemin des Triaudes")
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Before
+  fun setUp() {
+    userRepository = mock(UserRepository::class.java)
+    navController = mock(NavController::class.java)
+    // authRepository =  mock(AuthRepository::class.java)
+    seekerProfileViewModel = SeekerProfileViewModel(userRepository)
+    navigationActions = NavigationActions(navController)
+    // authViewModel = AuthViewModel(authRepository)
+    composeTestRule.setContent {
+      EditSeekerProfileScreen(seekerProfileViewModel, navigationActions)
+    }
+  }
+
+  @Test
+  fun inputsHaveInitialValue() {
+
+    `when`(userRepository.getUserProfile(eq("1234"), any(), any())).thenAnswer {
+      val onSuccess = it.getArgument<(SeekerProfile) -> Unit>(1)
+      onSuccess(testSeekerProfile) // Simulate success
+    }
+    // Call the ViewModel method
+    seekerProfileViewModel.getUserProfile("1234")
+
+    // Assert that the ViewModel's SeekerProfile was updated with the correct data
+    assertEquals(testSeekerProfile, seekerProfileViewModel.seekerProfile.value)
+    Thread.sleep(10000)
+
+    composeTestRule.onNodeWithTag("profileName").assertTextContains(testSeekerProfile.name)
+    composeTestRule.onNodeWithTag("profileUsername").assertTextContains(testSeekerProfile.username)
+    composeTestRule.onNodeWithTag("profileEmail").assertTextContains(testSeekerProfile.email)
+    composeTestRule.onNodeWithTag("profilePhone").assertTextContains(testSeekerProfile.phone)
+    composeTestRule.onNodeWithTag("profileAddress").assertTextContains(testSeekerProfile.address)
+  }
+}

--- a/app/src/main/java/com/android/solvit/seeker/model/profile/SeekerProfileViewModel.kt
+++ b/app/src/main/java/com/android/solvit/seeker/model/profile/SeekerProfileViewModel.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 class SeekerProfileViewModel(
-    private val repository: UserRepositoryFirestore,
+    private val repository: UserRepository,
 ) : ViewModel() {
 
   // private val _userProfile = MutableStateFlow<List<UserProfile>>(emptyList())

--- a/app/src/main/java/com/android/solvit/seeker/model/profile/SeekerProfileViewModel.kt
+++ b/app/src/main/java/com/android/solvit/seeker/model/profile/SeekerProfileViewModel.kt
@@ -1,5 +1,6 @@
 package com.android.solvit.seeker.model.profile
 
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -8,24 +9,39 @@ import com.google.firebase.Firebase
 import com.google.firebase.firestore.firestore
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 
-class SeekerProfileViewModel(private val repository: UserRepositoryFirestore) : ViewModel() {
+class SeekerProfileViewModel(
+    private val repository: UserRepositoryFirestore,
+) : ViewModel() {
 
   // private val _userProfile = MutableStateFlow<List<UserProfile>>(emptyList())
   // hardcode
   private val _seekerProfile =
-      MutableStateFlow(
-          listOf(
-              SeekerProfile(
-                  uid = "12345", // Hardcoded UID
-                  name = "John Doe", // Hardcoded Name
-                  username = "johndoe", // Hardcoded username
-                  email = "john.doe@example.com", // Hardcoded Email
-                  phone = "+1234567890", // Hardcoded Phone Number
-                  address = "Chemin des Triaudes" // Hardcoded Address
-                  )))
-  val seekerProfile: StateFlow<List<SeekerProfile>> = _seekerProfile.asStateFlow()
+      MutableStateFlow<SeekerProfile>(
+          SeekerProfile(
+              uid = "", // Hardcoded UID
+              name = "", // Hardcoded Name
+              username = "", // Hardcoded username
+              email = "", // Hardcoded Email
+              phone = "", // Hardcoded Phone Number
+              address = "" // Hardcoded Address
+              ))
+  val seekerProfile: StateFlow<SeekerProfile> = _seekerProfile
+
+  private val _seekerProfileList = MutableStateFlow<List<SeekerProfile>>(emptyList())
+  val seekerProfileList: StateFlow<List<SeekerProfile>> = _seekerProfileList
+
+  // create factory
+  companion object {
+    val Factory: ViewModelProvider.Factory =
+        object : ViewModelProvider.Factory {
+          @Suppress("UNCHECKED_CAST")
+          override fun <T : ViewModel> create(modelClass: Class<T>): T {
+
+            return SeekerProfileViewModel(UserRepositoryFirestore(Firebase.firestore)) as T
+          }
+        }
+  }
 
   private val _isLoading = MutableLiveData<Boolean>()
   val isLoading: LiveData<Boolean>
@@ -39,32 +55,31 @@ class SeekerProfileViewModel(private val repository: UserRepositoryFirestore) : 
     return repository.getNewUid()
   }
 
-  fun getUserProfile() {
-    repository.getUserProfile(onSuccess = { _seekerProfile.value = it }, onFailure = {})
+  init {
+    repository.init { getUsersProfile() }
   }
 
-  /*fun updateUserProfile(profile: UserProfile) {
-      repository.updateUserProfile(profile= profile , onSuccess = {  getUserProfile() }, onFailure = {})
+  fun getUserProfile(uid: String) {
+
+    repository.getUserProfile(
+        uid,
+        onSuccess = { _seekerProfile.value = it },
+        onFailure = { Log.e("SeekerProfileViewModel", "Failed to get user profile") })
   }
 
-   */
+  fun getUsersProfile() {
+    repository.getUsersProfile(onSuccess = { _seekerProfileList.value = it }, onFailure = {})
+  }
+
+  fun addUserProfile(profile: SeekerProfile) {
+    repository.addUserProfile(profile, onSuccess = { getUsersProfile() }, onFailure = {})
+  }
 
   fun updateUserProfile(profile: SeekerProfile) {
-    _seekerProfile.value = listOf(profile)
+    repository.updateUserProfile(profile, onSuccess = { getUsersProfile() }, onFailure = {})
   }
 
   fun deleteUserProfile(id: String) {
-    repository.deleteUserProfile(id = id, onSuccess = { getUserProfile() }, onFailure = {})
-  }
-
-  // create factory
-  companion object {
-    val Factory: ViewModelProvider.Factory =
-        object : ViewModelProvider.Factory {
-          @Suppress("UNCHECKED_CAST")
-          override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            return SeekerProfileViewModel(UserRepositoryFirestore(Firebase.firestore)) as T
-          }
-        }
+    repository.deleteUserProfile(id = id, onSuccess = { getUsersProfile() }, onFailure = {})
   }
 }

--- a/app/src/main/java/com/android/solvit/seeker/model/profile/UserRepository.kt
+++ b/app/src/main/java/com/android/solvit/seeker/model/profile/UserRepository.kt
@@ -21,9 +21,5 @@ interface UserRepository {
 
   fun addUserProfile(profile: SeekerProfile, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
 
-  fun getCurrentUserEmail(): String?
-
   fun deleteUserProfile(id: String, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
-
-  fun getCurrentUserPhoneNumber(): String?
 }

--- a/app/src/main/java/com/android/solvit/seeker/model/profile/UserRepository.kt
+++ b/app/src/main/java/com/android/solvit/seeker/model/profile/UserRepository.kt
@@ -5,13 +5,21 @@ interface UserRepository {
 
   fun init(onSuccess: () -> Unit)
 
-  fun getUserProfile(onSuccess: (List<SeekerProfile>) -> Unit, onFailure: (Exception) -> Unit)
+  fun getUsersProfile(onSuccess: (List<SeekerProfile>) -> Unit, onFailure: (Exception) -> Unit)
+
+  fun getUserProfile(
+      uid: String,
+      onSuccess: (SeekerProfile) -> Unit,
+      onFailure: (Exception) -> Unit
+  )
 
   fun updateUserProfile(
       profile: SeekerProfile,
       onSuccess: () -> Unit,
       onFailure: (Exception) -> Unit
   )
+
+  fun addUserProfile(profile: SeekerProfile, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
 
   fun getCurrentUserEmail(): String?
 

--- a/app/src/main/java/com/android/solvit/seeker/model/profile/UserRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/solvit/seeker/model/profile/UserRepositoryFirestore.kt
@@ -94,14 +94,6 @@ class UserRepositoryFirestore(private val db: FirebaseFirestore) : UserRepositor
         db.collection(collectionPath).document(id).delete(), onSuccess, onFailure)
   }
 
-  override fun getCurrentUserEmail(): String? {
-    return auth.currentUser?.email
-  }
-
-  override fun getCurrentUserPhoneNumber(): String? {
-    return auth.currentUser?.phoneNumber
-  }
-
   private fun performFirestoreOperation(
       task: Task<Void>,
       onSuccess: () -> Unit,

--- a/app/src/main/java/com/android/solvit/seeker/model/profile/UserRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/solvit/seeker/model/profile/UserRepositoryFirestore.kt
@@ -119,7 +119,7 @@ class UserRepositoryFirestore(private val db: FirebaseFirestore) : UserRepositor
     }
   }
 
-  private fun documentToUser(document: DocumentSnapshot): SeekerProfile? {
+  fun documentToUser(document: DocumentSnapshot): SeekerProfile? {
     return try {
       val uid = document.id
       val name = document.getString("name") ?: return null

--- a/app/src/main/java/com/android/solvit/seeker/ui/profile/EditSeekerProfile.kt
+++ b/app/src/main/java/com/android/solvit/seeker/ui/profile/EditSeekerProfile.kt
@@ -1,6 +1,5 @@
 package com.android.solvit.seeker.ui.profile
 
-import android.annotation.SuppressLint
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
@@ -17,236 +16,34 @@ import androidx.compose.ui.unit.dp
 import com.android.solvit.R
 import com.android.solvit.seeker.model.profile.SeekerProfile
 import com.android.solvit.seeker.model.profile.SeekerProfileViewModel
+import com.android.solvit.shared.model.authentication.AuthViewModel
 import com.android.solvit.shared.ui.navigation.NavigationActions
 
-/*
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun EditProfileScreen(
-    viewModel: ProfileViewModel,
-    navigationActions: NavigationActions
-) {
-    // Collect the user profile from the StateFlow
-    val userProfile by viewModel.userProfile.collectAsState()
-
-    // Assuming a single user profile (adjust as needed)
-    val currentProfile = userProfile.firstOrNull()
-
-    // Initialize fields with existing user data
-    var name by remember { mutableStateOf(currentProfile?.name ?: "") }
-    var email by remember { mutableStateOf(currentProfile?.email ?: "") }
-    var phone by remember { mutableStateOf(currentProfile?.phone ?: "") }
-
-    Scaffold(
-        modifier = Modifier.testTag("editScreen"),
-        topBar = {
-            TopAppBar(
-                title = { Text("Edit Profile", modifier = Modifier.testTag("editTodoTitle")) },
-                navigationIcon = {
-                    IconButton(
-                        modifier = Modifier.testTag("goBackButton"),
-                        onClick = { navigationActions.goBack() }) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Back")
-                    }
-                })
-        },
-        content = { paddingValues ->
-            Column(
-                modifier = Modifier
-                    .padding(paddingValues)
-                    .fillMaxSize()
-                    .padding(16.dp)
-            ) {
-                Spacer(modifier = Modifier.height(16.dp))
-
-                // Name Input
-                TextField(
-                    value = name,
-                    onValueChange = { name = it },
-                    label = { Text("Name") }
-                )
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                // Email Input
-                TextField(
-                    value = email,
-                    onValueChange = { email = it },
-                    label = { Text("Email") }
-                )
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                // Phone Input
-                TextField(
-                    value = phone,
-                    onValueChange = { phone = it },
-                    label = { Text("Phone") }
-                )
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                // Save Changes Button
-                Button(onClick = {
-                    currentProfile?.let { profile ->
-                        // Update the profile with the new values
-                        viewModel.updateUserProfile(
-                            UserProfile(
-                                uid = profile.uid, // Ensure to use the existing uid
-                                name = name,
-                                email = email,
-                                phone = phone
-                            )
-                        )
-                    }
-                    navigationActions.goBack()
-                }) {
-                    Text("Save Changes")
-                }
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                // Cancel Button to go back without saving
-                Button(onClick = {
-                    navigationActions.goBack() // Navigate back to the ProfileScreen without saving
-                }) {
-                    Text("Cancel")
-                }
-            }
-        }
-    )
-}
-*/
-
-/*
-@SuppressLint("UnusedMaterialScaffoldPaddingParameter")
-@Composable
-fun EditProfileScreen(
-    viewModel: ProfileViewModel,
-    navigationActions: NavigationActions
-) {
-    // Collect the user profile from the StateFlow
-    val userProfile by viewModel.userProfile.collectAsState()
-
-    // Assuming a single user profile (adjust as needed)
-    val currentProfile = userProfile.firstOrNull()
-
-    // Initialize fields with existing user data
-    var name by remember { mutableStateOf(currentProfile?.name ?: "") }
-    var email by remember { mutableStateOf(currentProfile?.email ?: "") }
-    var phone by remember { mutableStateOf(currentProfile?.phone ?: "") }
-
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text("Edit Profile") },
-                navigationIcon = {
-                    IconButton(onClick = { navigationActions.goBack() }) {
-                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
-                    }
-                }
-            )
-        }
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(16.dp)
-        ) {
-            Spacer(modifier = Modifier.height(16.dp))
-
-            // Profile Picture
-            Image(
-                painter = painterResource(id = R.drawable.empty_profile_img), // Replace with actual profile image later
-                contentDescription = "Profile Picture",
-                modifier = Modifier
-                    .size(100.dp)
-                    .clip(CircleShape)
-                    .border(2.dp, Color.Gray, CircleShape)
-                    .padding(bottom = 16.dp)
-            )
-            TextButton(onClick = { /* Handle change picture */ }) {
-                Text("Change Picture")
-            }
-
-            Spacer(modifier = Modifier.height(16.dp))
-
-            // Username Input
-            OutlinedTextField(
-                value = name,
-                onValueChange = { name = it },
-                label = { Text("Username") },
-                modifier = Modifier.fillMaxWidth()
-            )
-
-            Spacer(modifier = Modifier.height(16.dp))
-
-            // Email Input
-            OutlinedTextField(
-                value = email,
-                onValueChange = { email = it },
-                label = { Text("Email Id") },
-                modifier = Modifier.fillMaxWidth()
-            )
-
-            Spacer(modifier = Modifier.height(16.dp))
-
-            // Phone Input
-            OutlinedTextField(
-                value = phone,
-                onValueChange = { phone = it },
-                label = { Text("Phone Number") },
-                modifier = Modifier.fillMaxWidth()
-            )
-
-            Spacer(modifier = Modifier.height(16.dp))
-
-            // Update Button
-            Button(
-                onClick = {
-                    currentProfile?.let { profile ->
-                        // Update the profile with the new values
-                        viewModel.updateUserProfile(
-                            UserProfile(
-                                uid = profile.uid, // Use the existing UID
-                                name = name,
-                                email = email,
-                                phone = phone
-                            )
-                        )
-                    }
-                    navigationActions.goBack()
-                },
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Text("Update")
-            }
-        }
-    }
-}
-*/
-
-@SuppressLint("UnusedMaterialScaffoldPaddingParameter")
 @Composable
 fun EditSeekerProfileScreen(
     viewModel: SeekerProfileViewModel,
-    navigationActions: NavigationActions
+    navigationActions: NavigationActions,
+    authViewModel: AuthViewModel
 ) {
   // Collect the user profile from the StateFlow
+  val user by authViewModel.user.collectAsState()
   val userProfile by viewModel.seekerProfile.collectAsState()
+  user?.let { viewModel.getUserProfile(it.uid) }
+  // viewModel.getUserProfile("fRTusprXsOfd3bS7RD4z44xpLZh1")
 
-  // Assuming a single user profile (adjust as needed)
-  val currentProfile = userProfile.firstOrNull()
+  var fullName by remember { mutableStateOf("") }
+  var username by remember { mutableStateOf("") }
+  var email by remember { mutableStateOf("") }
+  var phone by remember { mutableStateOf("") }
+  var address by remember { mutableStateOf("") }
 
-  // Initialize fields with existing user data
-  var fullName by remember { mutableStateOf(currentProfile?.name ?: "") }
-  var username by remember { mutableStateOf(currentProfile?.username ?: "") }
-  var email by remember { mutableStateOf(currentProfile?.email ?: "") }
-  var phone by remember { mutableStateOf(currentProfile?.phone ?: "") }
-  var address by remember { mutableStateOf(currentProfile?.address ?: "") }
-
+  LaunchedEffect(userProfile) {
+    fullName = userProfile.name ?: ""
+    username = userProfile.username ?: ""
+    email = userProfile.email ?: ""
+    phone = userProfile.phone ?: ""
+    address = userProfile.address ?: ""
+  }
   Scaffold(
       topBar = {
         TopAppBar(
@@ -257,7 +54,7 @@ fun EditSeekerProfileScreen(
                 Icon(Icons.Default.ArrowBack, contentDescription = "Back", tint = Color.White)
               }
             })
-      }) {
+      }) { padding ->
         Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
           Spacer(modifier = Modifier.height(16.dp))
 
@@ -324,7 +121,7 @@ fun EditSeekerProfileScreen(
           // Save Button
           Button(
               onClick = {
-                currentProfile?.let { profile ->
+                userProfile?.let { profile ->
                   // Update the profile with the new values
                   viewModel.updateUserProfile(
                       SeekerProfile(

--- a/app/src/main/java/com/android/solvit/seeker/ui/profile/EditSeekerProfile.kt
+++ b/app/src/main/java/com/android/solvit/seeker/ui/profile/EditSeekerProfile.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.android.solvit.R
 import com.android.solvit.seeker.model.profile.SeekerProfile
 import com.android.solvit.seeker.model.profile.SeekerProfileViewModel
@@ -23,7 +24,7 @@ import com.android.solvit.shared.ui.navigation.NavigationActions
 fun EditSeekerProfileScreen(
     viewModel: SeekerProfileViewModel,
     navigationActions: NavigationActions,
-    authViewModel: AuthViewModel
+    authViewModel: AuthViewModel = viewModel(factory = AuthViewModel.Factory)
 ) {
   // Collect the user profile from the StateFlow
   val user by authViewModel.user.collectAsState()

--- a/app/src/main/java/com/android/solvit/seeker/ui/profile/EditSeekerProfile.kt
+++ b/app/src/main/java/com/android/solvit/seeker/ui/profile/EditSeekerProfile.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -79,7 +80,7 @@ fun EditSeekerProfileScreen(
               value = fullName,
               onValueChange = { fullName = it },
               label = { Text("Full Name") },
-              modifier = Modifier.fillMaxWidth())
+              modifier = Modifier.fillMaxWidth().testTag("profileName"))
 
           Spacer(modifier = Modifier.height(16.dp))
 
@@ -88,7 +89,7 @@ fun EditSeekerProfileScreen(
               value = username,
               onValueChange = { username = it },
               label = { Text("Username") },
-              modifier = Modifier.fillMaxWidth())
+              modifier = Modifier.fillMaxWidth().testTag("profileUsername"))
 
           Spacer(modifier = Modifier.height(16.dp))
 
@@ -97,7 +98,7 @@ fun EditSeekerProfileScreen(
               value = email,
               onValueChange = { email = it },
               label = { Text("Email") },
-              modifier = Modifier.fillMaxWidth())
+              modifier = Modifier.fillMaxWidth().testTag("profileEmail"))
 
           Spacer(modifier = Modifier.height(16.dp))
 
@@ -106,7 +107,7 @@ fun EditSeekerProfileScreen(
               value = phone,
               onValueChange = { phone = it },
               label = { Text("Phone Number") },
-              modifier = Modifier.fillMaxWidth())
+              modifier = Modifier.fillMaxWidth().testTag("profilePhone"))
 
           Spacer(modifier = Modifier.height(16.dp))
 
@@ -115,7 +116,7 @@ fun EditSeekerProfileScreen(
               value = address,
               onValueChange = { address = it },
               label = { Text("Address") },
-              modifier = Modifier.fillMaxWidth())
+              modifier = Modifier.fillMaxWidth().testTag("profileAddress"))
 
           Spacer(modifier = Modifier.height(16.dp))
 

--- a/app/src/main/java/com/android/solvit/seeker/ui/profile/SeekerProfile.kt
+++ b/app/src/main/java/com/android/solvit/seeker/ui/profile/SeekerProfile.kt
@@ -254,7 +254,7 @@ fun SeekerProfileScreen(viewModel: SeekerProfileViewModel, navigationActions: Na
   val userProfile by viewModel.seekerProfile.collectAsState()
 
   // Display the profile information if it's available
-  userProfile.firstOrNull()?.let { profile ->
+  userProfile.let { profile ->
     Scaffold(
         topBar = {
           TopAppBar(

--- a/app/src/test/java/com/android/solvit/seeker/model/profile/SeekerProfileViewModelTest.kt
+++ b/app/src/test/java/com/android/solvit/seeker/model/profile/SeekerProfileViewModelTest.kt
@@ -57,6 +57,12 @@ class SeekerProfileViewModelTest {
     verify(firebaseRepository).getUserProfile(any(), any(), any())
   }
 
+  @Test
+  fun addUserProfielCallsRepository() {
+    seekerProfileViewModel.addUserProfile(testProfile)
+    verify(firebaseRepository).addUserProfile(any(), any(), any())
+  }
+
   /*
   @Test
   fun updateUserProfileUpdatesLocalProfile() {

--- a/app/src/test/java/com/android/solvit/seeker/model/profile/SeekerProfileViewModelTest.kt
+++ b/app/src/test/java/com/android/solvit/seeker/model/profile/SeekerProfileViewModelTest.kt
@@ -1,5 +1,7 @@
 package com.android.solvit.seeker.model.profile
 
+import com.android.solvit.shared.model.authentication.AuthRepository
+import com.android.solvit.shared.model.authentication.AuthViewModel
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Before
@@ -11,6 +13,8 @@ import org.mockito.kotlin.eq
 class SeekerProfileViewModelTest {
 
   private lateinit var seekerProfileViewModel: SeekerProfileViewModel
+  private lateinit var authViewModel: AuthViewModel
+  private lateinit var authRepository: AuthRepository
   private lateinit var firebaseRepository: UserRepositoryFirestore
 
   val testProfile =
@@ -25,6 +29,8 @@ class SeekerProfileViewModelTest {
   @Before
   fun setUp() {
     firebaseRepository = mock(UserRepositoryFirestore::class.java)
+    authRepository = mock(AuthRepository::class.java)
+    authViewModel = AuthViewModel(authRepository)
     seekerProfileViewModel = SeekerProfileViewModel(firebaseRepository)
   }
 
@@ -38,19 +44,26 @@ class SeekerProfileViewModelTest {
   }
 
   @Test
-  fun getUserProfileCallsRepository() {
+  fun getUsersProfileCallsRepository() {
 
-    seekerProfileViewModel.getUserProfile()
-    verify(firebaseRepository).getUserProfile(any(), any())
+    seekerProfileViewModel.getUsersProfile()
+    verify(firebaseRepository).getUsersProfile(any(), any())
   }
 
+  @Test
+  fun getUserProfileCallsRepository() {
+    seekerProfileViewModel.getUserProfile("1234")
+    verify(firebaseRepository).getUserProfile(any(), any(), any())
+  }
+
+  /*
   @Test
   fun updateUserProfileUpdatesLocalProfile() {
 
     seekerProfileViewModel.updateUserProfile(testProfile)
     val updatedProfile = seekerProfileViewModel.seekerProfile.value
-    assertThat(updatedProfile[0], `is`(testProfile))
-  }
+    assertThat(updatedProfile, `is`(testProfile))
+  }*/
 
   @Test
   fun deleteUserProfileCallsRepository() {

--- a/app/src/test/java/com/android/solvit/seeker/model/profile/SeekerProfileViewModelTest.kt
+++ b/app/src/test/java/com/android/solvit/seeker/model/profile/SeekerProfileViewModelTest.kt
@@ -47,6 +47,7 @@ class SeekerProfileViewModelTest {
   fun getUsersProfileCallsRepository() {
 
     seekerProfileViewModel.getUsersProfile()
+
     verify(firebaseRepository).getUsersProfile(any(), any())
   }
 

--- a/app/src/test/java/com/android/solvit/seeker/model/profile/UserRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/android/solvit/seeker/model/profile/UserRepositoryFirestoreTest.kt
@@ -16,6 +16,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Mockito
+import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
 import org.mockito.kotlin.timeout
@@ -142,5 +143,29 @@ class UserRepositoryFirestoreTest {
     Shadows.shadowOf(Looper.getMainLooper()).idle()
 
     verify(mockDocumentReference).delete()
+  }
+
+  @Test
+  fun documentToUser_success() {
+    // Mock a DocumentSnapshot
+
+    // Simulate the document having all the necessary fields
+    `when`(mockDocumentSnapshot.id).thenReturn("12345")
+    `when`(mockDocumentSnapshot.getString("name")).thenReturn("John Doe")
+    `when`(mockDocumentSnapshot.getString("username")).thenReturn("johndoe")
+    `when`(mockDocumentSnapshot.getString("email")).thenReturn("john.doe@example.com")
+    `when`(mockDocumentSnapshot.getString("phone")).thenReturn("+1234567890")
+    `when`(mockDocumentSnapshot.getString("address")).thenReturn("Chemin des Triaudes")
+
+    // Call the helper method
+    val profile = firebaseRepository.documentToUser(mockDocumentSnapshot)
+
+    // Assert that the profile was correctly created
+    assertEquals("12345", profile?.uid)
+    assertEquals("John Doe", profile?.name)
+    assertEquals("johndoe", profile?.username)
+    assertEquals("john.doe@example.com", profile?.email)
+    assertEquals("+1234567890", profile?.phone)
+    assertEquals("Chemin des Triaudes", profile?.address)
   }
 }

--- a/app/src/test/java/com/android/solvit/seeker/model/profile/UserRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/android/solvit/seeker/model/profile/UserRepositoryFirestoreTest.kt
@@ -71,7 +71,7 @@ class UserRepositoryFirestoreTest {
 
     Mockito.`when`(mockQuerySnapshot.documents).thenReturn(listOf())
 
-    firebaseRepository.getUserProfile(
+    firebaseRepository.getUsersProfile(
         onSuccess = {
           // Do nothing; we just want to verify that the 'documents' field was accessed
         },

--- a/app/src/test/java/com/android/solvit/seeker/model/profile/UserRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/android/solvit/seeker/model/profile/UserRepositoryFirestoreTest.kt
@@ -10,6 +10,7 @@ import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.QuerySnapshot
 import junit.framework.TestCase
+import junit.framework.TestCase.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -66,6 +67,40 @@ class UserRepositoryFirestoreTest {
 
   @Test
   fun getUserProfile_callsFirestoreCollection() {
+    Mockito.`when`(mockDocumentReference.get()).thenReturn(Tasks.forResult(mockDocumentSnapshot))
+
+    Mockito.`when`(mockDocumentSnapshot.exists()).thenReturn(true)
+    // Mock the document snapshot to return data
+    Mockito.`when`(mockDocumentSnapshot.exists()).thenReturn(true)
+    Mockito.`when`(mockDocumentSnapshot.id).thenReturn(testSeekerProfile.uid)
+    Mockito.`when`(mockDocumentSnapshot.getString("name")).thenReturn(testSeekerProfile.name)
+    Mockito.`when`(mockDocumentSnapshot.getString("username"))
+        .thenReturn(testSeekerProfile.username)
+    Mockito.`when`(mockDocumentSnapshot.getString("email")).thenReturn(testSeekerProfile.email)
+    Mockito.`when`(mockDocumentSnapshot.getString("phone")).thenReturn(testSeekerProfile.phone)
+    Mockito.`when`(mockDocumentSnapshot.getString("address")).thenReturn(testSeekerProfile.address)
+
+    firebaseRepository.getUserProfile(
+        uid = "12345",
+        onSuccess = { profile ->
+          assertEquals(testSeekerProfile, profile) // Ensure correct profile is returned
+        },
+        onFailure = { TestCase.fail("Failure callback should not be called") })
+
+    verify(mockDocumentReference).get()
+  }
+
+  @Test
+  fun updateUserProfileTest() {
+    Mockito.`when`(mockDocumentReference.set(any())).thenReturn(Tasks.forResult(null))
+    firebaseRepository.updateUserProfile(
+        profile = testSeekerProfile, onSuccess = {}, onFailure = {})
+    Shadows.shadowOf(Looper.getMainLooper()).idle()
+    verify(mockDocumentReference).set(testSeekerProfile)
+  }
+
+  @Test
+  fun getUsersProfile_callsFirestoreCollection() {
 
     Mockito.`when`(mockCollectionReference.get()).thenReturn(Tasks.forResult(mockQuerySnapshot))
 


### PR DESCRIPTION
**Overview**
This PR links the backend to the frontend, allowing authenticated users to view and edit their profile. Upon login, the system retrieves the user's UID and uses it to fetch and display the user's information on the profile page.

**Key Changes**

- Authentication:
Retrieves the user's UID upon login and passes it to the frontend.
- Profile Display and Edit:
Populates user data in the UI and enables profile editing.
Updates are sent back to the backend via API.

**Testing**

- Verified functionality for viewing and editing profiles.
- Added unit tests for key components.

**Notes**

I have to call getUserProfile in the composable which may not be smooth for the user experience we have to call it later in the init of the repo