### PR TITLE
Set up the signing configuration in the Gradle build

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -62,11 +62,11 @@ jobs:
           echo "RELEASE_KEY_ALIAS=${{ secrets.RELEASE_KEY_ALIAS }}" >> local.properties
           echo "RELEASE_KEY_PASSWORD=${{ secrets.RELEASE_KEY_PASSWORD }}" >> local.properties
 
-      - name: Build APK
-        run: ./gradlew assembleDebug
+      - name: Build Release APK
+        run: ./gradlew assembleRelease
 
       - name: Upload APK
         uses: actions/upload-artifact@v3
         with:
-          name: M1-APK
-          path: app/build/outputs/apk/debug/app-debug.apk
+            name: M1-APK
+            path: app/build/outputs/apk/release/app-release.apk

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -54,7 +54,7 @@ jobs:
           
       - name: Sign the APK
         run: |
-          jarsigner -verbose -sigalg SHA256withRSA -digestalg SHA-256 -keystore release-keystore.jks -storepass $RELEASE_KEYSTORE_PASSWORD -keypass $RELEASE_KEY_PASSWORD app/build/outputs/apk/release/app-release-unsigned.apk $RELEASE_KEY_ALIAS
+          jarsigner -verbose -sigalg SHA256withRSA -digestalg SHA-256 -keystore app/release-key.jks -storepass $RELEASE_KEYSTORE_PASSWORD -keypass $RELEASE_KEY_PASSWORD app/build/outputs/apk/release/app-release-unsigned.apk $RELEASE_KEY_ALIAS
 
       - name: Grant execute permission for Gradlew
         run: chmod +x ./gradlew

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -54,7 +54,7 @@ jobs:
           
       - name: Sign the APK
         run: |
-          jarsigner -verbose -sigalg SHA256withRSA -digestalg SHA-256 -keystore app/release-key.jks -storepass $RELEASE_KEYSTORE_PASSWORD -keypass $RELEASE_KEY_PASSWORD app/build/outputs/apk/release/app-release-unsigned.apk $RELEASE_KEY_ALIAS
+          jarsigner -verbose -sigalg SHA256withRSA -digestalg SHA-256 -keystore ./app/release-key.jks -storepass $RELEASE_KEYSTORE_PASSWORD -keypass $RELEASE_KEY_PASSWORD app/build/outputs/apk/release/app-release-unsigned.apk $RELEASE_KEY_ALIAS
 
       - name: Grant execute permission for Gradlew
         run: chmod +x ./gradlew

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -42,6 +42,11 @@ jobs:
           RELEASE_KEYSTORE: ${{ secrets.RELEASE_KEYSTORE }}
         run: |
           echo "$RELEASE_KEYSTORE" | base64 --decode > ./app/release-key.jks
+          
+      - name: Debug alias
+        run: echo $RELEASE_KEY_ALIAS
+        env:
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
 
       # Cache Gradle packages to speed up the build process
       - name: Cache Gradle packages

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -63,10 +63,10 @@ jobs:
           echo "RELEASE_KEY_PASSWORD=${{ secrets.RELEASE_KEY_PASSWORD }}" >> local.properties
 
       - name: Build APK
-        run: ./gradlew assembleDebug
+        run: ./gradlew assembleRelease
 
       - name: Upload APK
         uses: actions/upload-artifact@v3
         with:
           name: M1-APK
-          path: app/build/outputs/apk/debug/app-debug.apk
+          path: app/build/outputs/apk/debug/app-release-unsigned.apk

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -69,4 +69,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: M1-APK
-          path: app/build/outputs/apk/debug/app-release-unsigned.apk
+          path: app/build/outputs/apk/release/app-release-unsigned.apk

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           echo "$RELEASE_KEYSTORE" | base64 --decode > ./app/release-key.jks
 
-      # Set up the signing configuration in the Gradle build
+      # Set up the signing configuration in the Gradle build and sign
       - name: Setup signing configuration
         run: |
           echo "RELEASE_STORE_FILE=app/release-key.jks" >> local.properties

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -4,12 +4,11 @@ on:
   push:
     branches:
       - main
-
   pull_request:
-          types:
-            - opened
-            - synchronize
-            - reopened
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 jobs:
   build:
@@ -34,8 +33,8 @@ jobs:
           GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
           LOCAL_PROPERTIES: ${{ secrets.LOCAL_PROPERTIES }}
         run: |
-            echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
-            echo "$LOCAL_PROPERTIES" | base64 --decode > ./local.properties
+          echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
+          echo "$LOCAL_PROPERTIES" | base64 --decode > ./local.properties
 
       # Decode the keystore
       - name: Decode release keystore
@@ -44,21 +43,7 @@ jobs:
         run: |
           echo "$RELEASE_KEYSTORE" | base64 --decode > ./app/release-key.jks
 
-      # Set up the signing configuration in the Gradle build and sign
-      - name: Setup signing configuration
-        run: |
-          echo "RELEASE_STORE_FILE=app/release-key.jks" >> local.properties
-          echo "RELEASE_STORE_PASSWORD=${{ secrets.RELEASE_KEYSTORE_PASSWORD }}" >> local.properties
-          echo "RELEASE_KEY_ALIAS=${{ secrets.RELEASE_KEY_ALIAS }}" >> local.properties
-          echo "RELEASE_KEY_PASSWORD=${{ secrets.RELEASE_KEY_PASSWORD }}" >> local.properties
-          
-      - name: Sign the APK
-        run: |
-          jarsigner -verbose -sigalg SHA256withRSA -digestalg SHA-256 -keystore ./app/release-key.jks -storepass $RELEASE_KEYSTORE_PASSWORD -keypass $RELEASE_KEY_PASSWORD app/build/outputs/apk/release/app-release-unsigned.apk $RELEASE_KEY_ALIAS
-
-      - name: Grant execute permission for Gradlew
-        run: chmod +x ./gradlew
-
+      # Cache Gradle packages to speed up the build process
       - name: Cache Gradle packages
         uses: actions/cache@v3
         with:
@@ -68,13 +53,29 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle
-            
 
-     
+      - name: Grant execute permission for Gradlew
+        run: chmod +x ./gradlew
 
+      # Build APK (or AAB)
       - name: Build APK
         run: ./gradlew assembleRelease
 
+      # Sign the APK (after building it)
+      - name: Sign the APK
+        run: |
+          jarsigner -verbose -sigalg SHA256withRSA -digestalg SHA-256 \
+          -keystore ./app/release-key.jks \
+          -storepass $RELEASE_KEYSTORE_PASSWORD \
+          -keypass $RELEASE_KEY_PASSWORD \
+          app/build/outputs/apk/release/app-release-unsigned.apk $RELEASE_KEY_ALIAS
+
+      # Optionally, rename the signed APK for consistency
+      - name: Rename signed APK
+        run: |
+          mv app/build/outputs/apk/release/app-release-unsigned.apk app/build/outputs/apk/release/app-release-signed.apk
+
+      # Upload APK
       - name: Upload APK
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -40,6 +40,10 @@ jobs:
           RELEASE_KEYSTORE: ${{ secrets.RELEASE_KEYSTORE }}
         run: |
           echo "$RELEASE_KEYSTORE" | base64 --decode > ./app/release-key.jks
+          
+      - name: Sign the APK
+        run: |
+          jarsigner -verbose -sigalg SHA256withRSA -digestalg SHA-256 -keystore release-keystore.jks -storepass $KEYSTORE_PASSWORD -keypass $KEY_PASSWORD app/build/outputs/apk/release/app-release-unsigned.apk $KEY_ALIAS
 
       - name: Grant execute permission for Gradlew
         run: chmod +x ./gradlew
@@ -53,6 +57,7 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle
+            
 
       # Set up the signing configuration in the Gradle build
       - name: Setup signing configuration
@@ -69,4 +74,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: M1-APK
-          path: app/build/outputs/apk/release/app-release-unsigned.apk
+          path: app/build/outputs/apk/release/app-release-signed.apk

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -28,6 +28,9 @@ jobs:
       # Load google-services.json and local.properties from the secrets
       - name: Decode secrets
         env:
+          RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
           GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
           LOCAL_PROPERTIES: ${{ secrets.LOCAL_PROPERTIES }}
         run: |
@@ -40,10 +43,18 @@ jobs:
           RELEASE_KEYSTORE: ${{ secrets.RELEASE_KEYSTORE }}
         run: |
           echo "$RELEASE_KEYSTORE" | base64 --decode > ./app/release-key.jks
+
+      # Set up the signing configuration in the Gradle build
+      - name: Setup signing configuration
+        run: |
+          echo "RELEASE_STORE_FILE=app/release-key.jks" >> local.properties
+          echo "RELEASE_STORE_PASSWORD=${{ secrets.RELEASE_KEYSTORE_PASSWORD }}" >> local.properties
+          echo "RELEASE_KEY_ALIAS=${{ secrets.RELEASE_KEY_ALIAS }}" >> local.properties
+          echo "RELEASE_KEY_PASSWORD=${{ secrets.RELEASE_KEY_PASSWORD }}" >> local.properties
           
       - name: Sign the APK
         run: |
-          jarsigner -verbose -sigalg SHA256withRSA -digestalg SHA-256 -keystore release-keystore.jks -storepass $KEYSTORE_PASSWORD -keypass $KEY_PASSWORD app/build/outputs/apk/release/app-release-unsigned.apk $KEY_ALIAS
+          jarsigner -verbose -sigalg SHA256withRSA -digestalg SHA-256 -keystore release-keystore.jks -storepass $RELEASE_KEYSTORE_PASSWORD -keypass $RELEASE_KEY_PASSWORD app/build/outputs/apk/release/app-release-unsigned.apk $RELEASE_KEY_ALIAS
 
       - name: Grant execute permission for Gradlew
         run: chmod +x ./gradlew
@@ -59,13 +70,7 @@ jobs:
             ${{ runner.os }}-gradle
             
 
-      # Set up the signing configuration in the Gradle build
-      - name: Setup signing configuration
-        run: |
-          echo "RELEASE_STORE_FILE=app/release-key.jks" >> local.properties
-          echo "RELEASE_STORE_PASSWORD=${{ secrets.RELEASE_KEYSTORE_PASSWORD }}" >> local.properties
-          echo "RELEASE_KEY_ALIAS=${{ secrets.RELEASE_KEY_ALIAS }}" >> local.properties
-          echo "RELEASE_KEY_PASSWORD=${{ secrets.RELEASE_KEY_PASSWORD }}" >> local.properties
+     
 
       - name: Build APK
         run: ./gradlew assembleRelease

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -34,6 +34,13 @@ jobs:
             echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
             echo "$LOCAL_PROPERTIES" | base64 --decode > ./local.properties
 
+      # Decode the keystore
+      - name: Decode release keystore
+        env:
+          RELEASE_KEYSTORE: ${{ secrets.RELEASE_KEYSTORE }}
+        run: |
+          echo "$RELEASE_KEYSTORE" | base64 --decode > ./app/release-key.jks
+
       - name: Grant execute permission for Gradlew
         run: chmod +x ./gradlew
 
@@ -46,6 +53,14 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle
+
+      # Set up the signing configuration in the Gradle build
+      - name: Setup signing configuration
+        run: |
+          echo "RELEASE_STORE_FILE=app/release-key.jks" >> local.properties
+          echo "RELEASE_STORE_PASSWORD=${{ secrets.RELEASE_KEYSTORE_PASSWORD }}" >> local.properties
+          echo "RELEASE_KEY_ALIAS=${{ secrets.RELEASE_KEY_ALIAS }}" >> local.properties
+          echo "RELEASE_KEY_PASSWORD=${{ secrets.RELEASE_KEY_PASSWORD }}" >> local.properties
 
       - name: Build APK
         run: ./gradlew assembleDebug

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -62,11 +62,11 @@ jobs:
           echo "RELEASE_KEY_ALIAS=${{ secrets.RELEASE_KEY_ALIAS }}" >> local.properties
           echo "RELEASE_KEY_PASSWORD=${{ secrets.RELEASE_KEY_PASSWORD }}" >> local.properties
 
-      - name: Build Release APK
-        run: ./gradlew assembleRelease
+      - name: Build APK
+        run: ./gradlew assembleDebug
 
       - name: Upload APK
         uses: actions/upload-artifact@v3
         with:
-            name: M1-APK
-            path: app/build/outputs/apk/release/app-release.apk
+          name: M1-APK
+          path: app/build/outputs/apk/debug/app-debug.apk


### PR DESCRIPTION
Configured APK signing in the Gradle build by setting up the signingConfigs block and integrating it with the release build type. Additionally, added steps to the GitHub Actions workflow to decode the keystore securely during the job execution, enabling automatic APK signing as part of the CI/