### PR TITLE
Get Directions Bubble For Itinerary Forecast

### DIFF
--- a/app/src/androidTest/java/com/android/solvit/shared/ui/map/GetDirectionsBubbleTest.kt
+++ b/app/src/androidTest/java/com/android/solvit/shared/ui/map/GetDirectionsBubbleTest.kt
@@ -1,0 +1,85 @@
+package com.android.solvit.shared.ui.map
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.core.app.ApplicationProvider
+import com.android.solvit.shared.model.map.Location
+import org.junit.Rule
+import org.junit.Test
+
+class GetDirectionsBubbleTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun testGetDirectionsBubble_DisplaysLocationName() {
+        val location = Location(name = "Test Location", latitude = 0.0, longitude = 0.0)
+        composeTestRule.setContent {
+            GetDirectionsBubble(location = location, onDismiss = {})
+        }
+
+        composeTestRule.onNodeWithText("Test Location").assertIsDisplayed()
+    }
+
+    @Test
+    fun testGetDirectionsBubble_GetDirectionsButton() {
+        val location = Location(name = "Test Location", latitude = 0.0, longitude = 0.0)
+        composeTestRule.setContent {
+            GetDirectionsBubble(location = location, onDismiss = {})
+        }
+
+        composeTestRule.onNodeWithText("Get Directions").assertIsDisplayed()
+    }
+
+    @Test
+    fun testGetDirectionsBubble_ClickGetDirectionsButton() {
+        val location = Location(name = "Test Location", latitude = 0.0, longitude = 0.0)
+        composeTestRule.setContent {
+            GetDirectionsBubble(location = location, onDismiss = {})
+        }
+
+        composeTestRule.onNodeWithText("Get Directions").performClick()
+
+        val expectedUri = Uri.parse("google.navigation:q=0.0,0.0")
+        val expectedIntent = Intent(Intent.ACTION_VIEW, expectedUri).apply {
+            setPackage("com.google.android.apps.maps")
+        }
+
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val resolvedActivity = expectedIntent.resolveActivity(context.packageManager)
+        assert(resolvedActivity != null)
+    }
+
+    @Test
+    fun testGetDirectionsBubble_FallbackToBrowser() {
+        val location = Location(name = "Test Location", latitude = 0.0, longitude = 0.0)
+        composeTestRule.setContent {
+            GetDirectionsBubble(location = location, onDismiss = {})
+        }
+
+        composeTestRule.onNodeWithText("Get Directions").performClick()
+
+        val expectedUri = Uri.parse("https://www.google.com/maps/dir/?api=1&destination=0.0,0.0")
+        val expectedIntent = Intent(Intent.ACTION_VIEW, expectedUri)
+
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val resolvedActivity = expectedIntent.resolveActivity(context.packageManager)
+        assert(resolvedActivity != null)
+    }
+
+    @Test
+    fun testGetDirectionsBubble_DismissOnButtonClick() {
+        var dismissed = false
+        val location = Location(name = "Test Location", latitude = 0.0, longitude = 0.0)
+        composeTestRule.setContent {
+            GetDirectionsBubble(location = location, onDismiss = { dismissed = true })
+        }
+
+        composeTestRule.onNodeWithText("Get Directions").performClick()
+        assert(dismissed)
+    }
+}

--- a/app/src/androidTest/java/com/android/solvit/shared/ui/map/GetDirectionsBubbleTest.kt
+++ b/app/src/androidTest/java/com/android/solvit/shared/ui/map/GetDirectionsBubbleTest.kt
@@ -12,74 +12,64 @@ import org.junit.Test
 
 class GetDirectionsBubbleTest {
 
-    @get:Rule
-    val composeTestRule = createComposeRule()
+  @get:Rule val composeTestRule = createComposeRule()
 
-    @Test
-    fun testGetDirectionsBubble_DisplaysLocationName() {
-        val location = Location(name = "Test Location", latitude = 0.0, longitude = 0.0)
-        composeTestRule.setContent {
-            GetDirectionsBubble(location = location, onDismiss = {})
-        }
+  @Test
+  fun testGetDirectionsBubble_DisplaysLocationName() {
+    val location = Location(name = "Test Location", latitude = 0.0, longitude = 0.0)
+    composeTestRule.setContent { GetDirectionsBubble(location = location, onDismiss = {}) }
 
-        composeTestRule.onNodeWithText("Test Location").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Test Location").assertIsDisplayed()
+  }
+
+  @Test
+  fun testGetDirectionsBubble_GetDirectionsButton() {
+    val location = Location(name = "Test Location", latitude = 0.0, longitude = 0.0)
+    composeTestRule.setContent { GetDirectionsBubble(location = location, onDismiss = {}) }
+
+    composeTestRule.onNodeWithText("Get Directions").assertIsDisplayed()
+  }
+
+  @Test
+  fun testGetDirectionsBubble_ClickGetDirectionsButton() {
+    val location = Location(name = "Test Location", latitude = 0.0, longitude = 0.0)
+    composeTestRule.setContent { GetDirectionsBubble(location = location, onDismiss = {}) }
+
+    composeTestRule.onNodeWithText("Get Directions").performClick()
+
+    val expectedUri = Uri.parse("google.navigation:q=0.0,0.0")
+    val expectedIntent =
+        Intent(Intent.ACTION_VIEW, expectedUri).apply { setPackage("com.google.android.apps.maps") }
+
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    val resolvedActivity = expectedIntent.resolveActivity(context.packageManager)
+    assert(resolvedActivity != null)
+  }
+
+  @Test
+  fun testGetDirectionsBubble_FallbackToBrowser() {
+    val location = Location(name = "Test Location", latitude = 0.0, longitude = 0.0)
+    composeTestRule.setContent { GetDirectionsBubble(location = location, onDismiss = {}) }
+
+    composeTestRule.onNodeWithText("Get Directions").performClick()
+
+    val expectedUri = Uri.parse("https://www.google.com/maps/dir/?api=1&destination=0.0,0.0")
+    val expectedIntent = Intent(Intent.ACTION_VIEW, expectedUri)
+
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    val resolvedActivity = expectedIntent.resolveActivity(context.packageManager)
+    assert(resolvedActivity != null)
+  }
+
+  @Test
+  fun testGetDirectionsBubble_DismissOnButtonClick() {
+    var dismissed = false
+    val location = Location(name = "Test Location", latitude = 0.0, longitude = 0.0)
+    composeTestRule.setContent {
+      GetDirectionsBubble(location = location, onDismiss = { dismissed = true })
     }
 
-    @Test
-    fun testGetDirectionsBubble_GetDirectionsButton() {
-        val location = Location(name = "Test Location", latitude = 0.0, longitude = 0.0)
-        composeTestRule.setContent {
-            GetDirectionsBubble(location = location, onDismiss = {})
-        }
-
-        composeTestRule.onNodeWithText("Get Directions").assertIsDisplayed()
-    }
-
-    @Test
-    fun testGetDirectionsBubble_ClickGetDirectionsButton() {
-        val location = Location(name = "Test Location", latitude = 0.0, longitude = 0.0)
-        composeTestRule.setContent {
-            GetDirectionsBubble(location = location, onDismiss = {})
-        }
-
-        composeTestRule.onNodeWithText("Get Directions").performClick()
-
-        val expectedUri = Uri.parse("google.navigation:q=0.0,0.0")
-        val expectedIntent = Intent(Intent.ACTION_VIEW, expectedUri).apply {
-            setPackage("com.google.android.apps.maps")
-        }
-
-        val context = ApplicationProvider.getApplicationContext<Context>()
-        val resolvedActivity = expectedIntent.resolveActivity(context.packageManager)
-        assert(resolvedActivity != null)
-    }
-
-    @Test
-    fun testGetDirectionsBubble_FallbackToBrowser() {
-        val location = Location(name = "Test Location", latitude = 0.0, longitude = 0.0)
-        composeTestRule.setContent {
-            GetDirectionsBubble(location = location, onDismiss = {})
-        }
-
-        composeTestRule.onNodeWithText("Get Directions").performClick()
-
-        val expectedUri = Uri.parse("https://www.google.com/maps/dir/?api=1&destination=0.0,0.0")
-        val expectedIntent = Intent(Intent.ACTION_VIEW, expectedUri)
-
-        val context = ApplicationProvider.getApplicationContext<Context>()
-        val resolvedActivity = expectedIntent.resolveActivity(context.packageManager)
-        assert(resolvedActivity != null)
-    }
-
-    @Test
-    fun testGetDirectionsBubble_DismissOnButtonClick() {
-        var dismissed = false
-        val location = Location(name = "Test Location", latitude = 0.0, longitude = 0.0)
-        composeTestRule.setContent {
-            GetDirectionsBubble(location = location, onDismiss = { dismissed = true })
-        }
-
-        composeTestRule.onNodeWithText("Get Directions").performClick()
-        assert(dismissed)
-    }
+    composeTestRule.onNodeWithText("Get Directions").performClick()
+    assert(dismissed)
+  }
 }

--- a/app/src/main/java/com/android/solvit/seeker/ui/request/ListRequestsFeed.kt
+++ b/app/src/main/java/com/android/solvit/seeker/ui/request/ListRequestsFeed.kt
@@ -63,9 +63,11 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.AsyncImage
 import com.android.solvit.R
 import com.android.solvit.seeker.ui.navigation.SeekerBottomNavigationMenu
+import com.android.solvit.shared.model.map.Location
 import com.android.solvit.shared.model.request.ServiceRequest
 import com.android.solvit.shared.model.request.ServiceRequestViewModel
 import com.android.solvit.shared.model.service.Services
+import com.android.solvit.shared.ui.map.GetDirectionsBubble
 import com.android.solvit.shared.ui.navigation.LIST_TOP_LEVEL_DESTINATION_PROVIDER
 import com.android.solvit.shared.ui.navigation.NavigationActions
 
@@ -197,6 +199,7 @@ fun TitleScreen() {
 // Displays a list of service requests using LazyColumn
 @Composable
 fun ListRequests(requests: List<ServiceRequest>) {
+  var selectedLocation by remember { mutableStateOf<Location?>(null) }
   LazyColumn(
       modifier = Modifier.fillMaxSize().testTag("requests"),
       contentPadding = PaddingValues(16.dp),
@@ -239,7 +242,11 @@ fun ListRequests(requests: List<ServiceRequest>) {
                             letterSpacing = 1.sp,
                         )
                         request.location?.let {
-                          Text(text = it.name, fontSize = 12.sp, color = Color.Gray)
+                          Text(
+                              text = it.name,
+                              fontSize = 12.sp,
+                              color = Color.Gray,
+                              modifier = Modifier.clickable { selectedLocation = it })
                         }
                         // TODO date request was created
 
@@ -295,6 +302,9 @@ fun ListRequests(requests: List<ServiceRequest>) {
                       InteractionBar("Share", R.drawable.share_icon)
                       InteractionBar("Reply", R.drawable.reply_icon)
                     }
+                selectedLocation?.let {
+                  GetDirectionsBubble(location = it) { selectedLocation = null }
+                }
               }
         }
       }

--- a/app/src/main/java/com/android/solvit/shared/ui/map/GetDirectiosBubble.kt
+++ b/app/src/main/java/com/android/solvit/shared/ui/map/GetDirectiosBubble.kt
@@ -4,7 +4,9 @@ import android.content.Intent
 import android.net.Uri
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.Surface
@@ -22,7 +24,7 @@ fun GetDirectionsBubble(location: Location, onDismiss: () -> Unit) {
   val context = LocalContext.current
   Dialog(onDismissRequest = onDismiss) {
     Surface(
-        shape = RoundedCornerShape(16.dp),
+        shape = RoundedCornerShape(32.dp),
         shadowElevation = 8.dp,
         modifier = Modifier.padding(16.dp)) {
           Column(
@@ -30,7 +32,7 @@ fun GetDirectionsBubble(location: Location, onDismiss: () -> Unit) {
               verticalArrangement = Arrangement.Center,
               horizontalAlignment = Alignment.CenterHorizontally) {
                 Text(text = location.name)
-
+                Spacer(modifier = Modifier.size(16.dp))
                 Button(
                     onClick = {
                       val gmmIntentUri =

--- a/app/src/main/java/com/android/solvit/shared/ui/map/GetDirectiosBubble.kt
+++ b/app/src/main/java/com/android/solvit/shared/ui/map/GetDirectiosBubble.kt
@@ -1,0 +1,64 @@
+package com.android.solvit.shared.ui.map
+
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.android.solvit.shared.model.map.Location
+
+@Composable
+fun GetDirectionsBubble(location: Location, onDismiss: () -> Unit) {
+  val context = LocalContext.current
+  Dialog(onDismissRequest = onDismiss) {
+    Surface(
+        shape = RoundedCornerShape(16.dp),
+        shadowElevation = 8.dp,
+        modifier = Modifier.padding(16.dp)) {
+          Column(
+              modifier = Modifier.padding(16.dp),
+              verticalArrangement = Arrangement.Center,
+              horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(text = location.name)
+
+                Button(
+                    onClick = {
+                      val gmmIntentUri =
+                          Uri.parse(
+                              "google.navigation:q=${location.latitude},${location.longitude}")
+                      val mapIntent =
+                          Intent(Intent.ACTION_VIEW, gmmIntentUri).apply {
+                            setPackage("com.google.android.apps.maps")
+                          }
+
+                      if (mapIntent.resolveActivity(context.packageManager) != null) {
+                        context.startActivity(mapIntent)
+                      } else {
+                        // Fallback to a browser if Google Maps is not available
+                        val browserIntent =
+                            Intent(
+                                Intent.ACTION_VIEW,
+                                Uri.parse(
+                                    "https://www.google.com/maps/dir/?api=1&destination=${location.latitude},${location.longitude}"))
+                        context.startActivity(browserIntent)
+                      }
+
+                      // Dismiss the bubble after clicking "Get Directions"
+                      onDismiss()
+                    }) {
+                      Text("Get Directions")
+                    }
+              }
+        }
+  }
+}

--- a/app/src/main/java/com/android/solvit/shared/ui/map/GetDirectiosBubble.kt
+++ b/app/src/main/java/com/android/solvit/shared/ui/map/GetDirectiosBubble.kt
@@ -2,6 +2,7 @@ package com.android.solvit.shared.ui.map
 
 import android.content.Intent
 import android.net.Uri
+import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -52,7 +53,12 @@ fun GetDirectionsBubble(location: Location, onDismiss: () -> Unit) {
                                 Intent.ACTION_VIEW,
                                 Uri.parse(
                                     "https://www.google.com/maps/dir/?api=1&destination=${location.latitude},${location.longitude}"))
-                        context.startActivity(browserIntent)
+                        if (browserIntent.resolveActivity(context.packageManager) != null) {
+                          context.startActivity(browserIntent)
+                        } else {
+                          Toast.makeText(context, "No navigation app available", Toast.LENGTH_SHORT)
+                              .show()
+                        }
                       }
 
                       // Dismiss the bubble after clicking "Get Directions"


### PR DESCRIPTION
### Description:
This PR adds the feature to get itinerary forecasts. Upon click on a location the user is shown a bubble with a Get Directions Button that redirects him to Google Maps Navigation

### Related Issues
- Fixes #218 

### Changes Made:
- Created `GetDirectionsBuuble` composable
- Created `GetDirectionsBubbleTest` for testing