### PR TITLE
BottomNavigationMenu handles dark mode

### DIFF
--- a/app/src/main/java/com/android/solvit/seeker/ui/navigation/BottomNavigationMenu.kt
+++ b/app/src/main/java/com/android/solvit/seeker/ui/navigation/BottomNavigationMenu.kt
@@ -13,12 +13,14 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.BottomNavigationItem
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationBarItemDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Alignment
@@ -49,10 +51,13 @@ fun BottomNavigationMenu(
     onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
   }
 
+  // Get the background color from the theme
+  val backgroundColor = MaterialTheme.colorScheme.background
+
   BoxWithConstraints(
       modifier =
           Modifier.fillMaxWidth()
-              .height(80.dp)
+              .height(60.dp)
               .background(Color.Transparent)
               .testTag("bottomNavigationMenu"),
       contentAlignment = Alignment.BottomCenter) {
@@ -70,8 +75,7 @@ fun BottomNavigationMenu(
                     0f,
                     size.width * 0.77f,
                     10.dp.toPx())
-                quadraticBezierTo(
-                    size.width * 0.86f, 60.dp.toPx(), size.width * 0.96f, 10.dp.toPx())
+                quadraticTo(size.width * 0.86f, 60.dp.toPx(), size.width * 0.96f, 10.dp.toPx())
 
                 cubicTo(
                     size.width * 0.96f, 10.dp.toPx(), size.width * 0.98f, 0f, size.width * 1f, 0f)
@@ -81,7 +85,7 @@ fun BottomNavigationMenu(
                 close()
               }
 
-          drawPath(path = path, color = Color(0xFFFFFFFF), style = Fill)
+          drawPath(path = path, color = backgroundColor, style = Fill)
         }
 
         Row(
@@ -89,18 +93,23 @@ fun BottomNavigationMenu(
             horizontalArrangement = Arrangement.Start,
             verticalAlignment = Alignment.CenterVertically) {
               val filteredTabList = tabList.filter { it.route != Route.CREATE_REQUEST }
-              filteredTabList.forEachIndexed { index, tab ->
-                BottomNavigationItem(
+              filteredTabList.forEachIndexed { _, tab ->
+                NavigationBarItem(
                     icon = {
                       Icon(
                           tab.icon,
                           contentDescription = null,
                           tint =
-                              if (tab.route == selectedItem) Color(0xFF0099FF)
-                              else Color(0xFFD8D8D8))
+                              if (tab.route == selectedItem) MaterialTheme.colorScheme.onBackground
+                              else MaterialTheme.colorScheme.onSurfaceVariant)
                     },
                     selected = tab.route == selectedItem,
                     onClick = { onTabSelect(tab) },
+                    colors =
+                        NavigationBarItemDefaults.colors(
+                            selectedIconColor = MaterialTheme.colorScheme.primary,
+                            unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                            indicatorColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.2f)),
                     modifier = Modifier.testTag(tab.textId))
               }
             }
@@ -115,7 +124,7 @@ fun BottomNavigationMenu(
             modifier =
                 Modifier.size(height * 0.85f)
                     .offset(y = (-25).dp)
-                    .offset(x = width * 0.5f - 53.dp)
+                    .offset(x = width * 0.5f - 56.dp)
                     .align(Alignment.TopCenter)
                     .testTag(TopLevelDestinations.CREATE_REQUEST.toString()),
             shape = CircleShape,


### PR DESCRIPTION
### Description:
This pull request enhances the `BottomNavigationMenu` to support dark mode.

- **What issue does it solve?** This PR improves the appearance of the `BottomNavigationMenu` by adapting it to dark mode, ensuring the app’s navigation is visually consistent across different themes.
- **What functionality does it add?** The `BottomNavigationMenu` now dynamically adjusts its colors based on the active seamlessly transitioning between light and dark modes for better accessibility and aesthetic.

### Related Issues:
- #291 

### Changes Made:
- Modified `BottomNavigationMenu` to adapt its colors using the MaterialTheme color scheme.
- Updated styling and applied theme-based color adjustments to most elements within the `BottomNavigationMenu`.
- Adjusted the height of the menu that caused some screens to have a whitespace between the bottom part of the screen and the navigation menu.
- Transitioned from the `material.BottomNavigationItem` to the `material3.NavigationBarItem` which simplifies the implementation of the `BottomNavigationMenu` and has cool new features.

### How to Test:
1. Toggle dark mode on the device or in the app’s settings, and verify that the `BottomNavigationMenu` adapts to the dark color scheme.
2. Switch back to light mode and confirm that the colors adjust to match the light theme.
3. Ensure all icons and labels within the `BottomNavigationMenu` remain visible and maintain contrast in both themes.

---

### Checklist:
- [x] Code adheres to project coding standards.
- [x] New and updated tests have been written and verified.
- [x] Functionality has been manually tested.
- [x] Code is free of known issues.
- [x] Documentation has been updated where applicable.

--- 
<img width="336" alt="Capture d’écran 2024-11-11 à 16 42 15" src="https://github.com/user-attachments/assets/23fe9be1-7a5c-4dd9-8204-9e894053c8a1">
<img width="336" alt="Capture d’écran 2024-11-11 à 16 42 47" src="https://github.com/user-attachments/assets/e0c6776a-6595-48a6-b1fb-f4bbc90a591c">