### PR TITLE
Package Proposals Frontend

### DIFF
--- a/app/src/androidTest/java/com/android/solvit/seeker/ui/provider/ProviderInfoTest.kt
+++ b/app/src/androidTest/java/com/android/solvit/seeker/ui/provider/ProviderInfoTest.kt
@@ -13,6 +13,7 @@ import androidx.navigation.NavController
 import com.android.solvit.seeker.model.provider.ListProviderViewModel
 import com.android.solvit.shared.model.map.Location
 import com.android.solvit.shared.model.provider.Language
+import com.android.solvit.shared.model.provider.PackageProposal
 import com.android.solvit.shared.model.provider.Provider
 import com.android.solvit.shared.model.provider.ProviderRepository
 import com.android.solvit.shared.model.review.Review
@@ -97,10 +98,14 @@ class ProviderInfoTest {
     composeTestRule.onNodeWithTag("providerTabs").assertIsDisplayed()
     composeTestRule.onNodeWithTag("profileTab").assertIsDisplayed()
     composeTestRule.onNodeWithTag("reviewsTab").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("packagesTab").assertIsDisplayed()
     composeTestRule.onNodeWithTag("profileTab").performClick()
+    composeTestRule.onNodeWithTag("packagesTab").assertIsDisplayed()
     assertEquals(0, selectedTabIndex)
-    composeTestRule.onNodeWithTag("reviewsTab").performClick()
+    composeTestRule.onNodeWithTag("packagesTab").performClick()
     assertEquals(1, selectedTabIndex)
+    composeTestRule.onNodeWithTag("reviewsTab").performClick()
+    assertEquals(2, selectedTabIndex)
   }
 
   @Test
@@ -135,6 +140,42 @@ class ProviderInfoTest {
     composeTestRule.onAllNodesWithTag("reviewComment")[0].assertTextEquals("Very good tutor")
     composeTestRule.onAllNodesWithTag("reviewComment")[1].assertTextEquals("Good tutor")
     composeTestRule.onAllNodesWithTag("reviewComment")[2].assertTextEquals("Average tutor")
+  }
+
+  @Test
+  fun providerPackagesDisplayCorrectly() {
+    composeTestRule.setContent {
+      ProviderPackages(
+          provider,
+          packages =
+              listOf(
+                  PackageProposal(
+                      uid = "1",
+                      title = "Basic Maintenance",
+                      description = "Ideal for minor repairs and maintenance tasks.",
+                      price = 49.99,
+                      bulletPoints =
+                          listOf(
+                              "Fix leaky faucets",
+                              "Unclog drains",
+                              "Inspect plumbing for minor issues")),
+                  PackageProposal(
+                      uid = "2",
+                      title = "Standard Service",
+                      description = "Comprehensive service for common plumbing needs.",
+                      price = 89.99,
+                      bulletPoints =
+                          listOf(
+                              "Repair leaks and clogs",
+                              "Replace faucets and fixtures",
+                              "Inspect and clear drain pipes")),
+              ))
+    }
+    composeTestRule.onNodeWithTag("packagesScrollableList").assertIsDisplayed()
+    assertEquals(
+        composeTestRule.onAllNodesWithTag("PackageCard").fetchSemanticsNodes().isNotEmpty(), true)
+    composeTestRule.onAllNodesWithTag("PackageCard")[0].assertIsDisplayed()
+    composeTestRule.onAllNodesWithTag("PackageCard")[1].assertIsDisplayed()
   }
 
   @Test
@@ -186,5 +227,7 @@ class ProviderInfoTest {
     composeTestRule.onNodeWithTag("providerDetails").assertIsDisplayed()
     composeTestRule.onNodeWithTag("reviewsTab").performClick()
     composeTestRule.onNodeWithTag("providerReviews").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("packagesTab").performClick()
+    composeTestRule.onNodeWithTag("packagesScrollableList").assertIsDisplayed()
   }
 }

--- a/app/src/main/java/com/android/solvit/seeker/ui/provider/ProviderInfo.kt
+++ b/app/src/main/java/com/android/solvit/seeker/ui/provider/ProviderInfo.kt
@@ -130,6 +130,7 @@ fun PackageCard(packageProposal: PackageProposal, isSelected: Boolean, modifier:
               // Price of the Package
               Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
+                    modifier = Modifier.testTag("price"),
                     text = "$${packageProposal.price}",
                     style =
                         MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),

--- a/app/src/main/java/com/android/solvit/seeker/ui/provider/ProviderInfo.kt
+++ b/app/src/main/java/com/android/solvit/seeker/ui/provider/ProviderInfo.kt
@@ -1,21 +1,26 @@
 package com.android.solvit.seeker.ui.provider
 
 import android.widget.Toast
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -34,6 +39,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.AsyncImage
 import com.android.solvit.R
 import com.android.solvit.seeker.model.provider.ListProviderViewModel
+import com.android.solvit.shared.model.provider.PackageProposal
 import com.android.solvit.shared.model.provider.Provider
 import com.android.solvit.shared.model.review.Review
 import com.android.solvit.shared.model.review.ReviewViewModel
@@ -51,6 +57,39 @@ fun ProviderInfoScreen(
 
   var selectedTabIndex by remember { mutableIntStateOf(0) }
 
+  // Since We still don't give the possibility to provider to add packages (for the moment we're use
+  // a default list of packages for all providers)
+  val packages =
+      listOf(
+          PackageProposal(
+              uid = "1",
+              title = "Basic Maintenance",
+              description = "Ideal for minor repairs and maintenance tasks.",
+              price = 49.99,
+              bulletPoints =
+                  listOf(
+                      "Fix leaky faucets", "Unclog drains", "Inspect plumbing for minor issues")),
+          PackageProposal(
+              uid = "2",
+              title = "Standard Service",
+              description = "Comprehensive service for common plumbing needs.",
+              price = 89.99,
+              bulletPoints =
+                  listOf(
+                      "Repair leaks and clogs",
+                      "Replace faucets and fixtures",
+                      "Inspect and clear drain pipes")),
+          PackageProposal(
+              uid = "3",
+              title = "Premium Installation",
+              description = "For extensive plumbing work, including installations.",
+              price = 149.99,
+              bulletPoints =
+                  listOf(
+                      "Install new water heater",
+                      "Full pipe installation or replacement",
+                      "Advanced leak detection and repair")))
+
   Scaffold(
       topBar = { ProviderTopBar(onBackClick = { navigationActions.goBack() }) },
       content = { padding ->
@@ -63,13 +102,119 @@ fun ProviderInfoScreen(
             0 ->
                 ProviderDetails(
                     provider, reviews) // Display ProviderDetails if "Profile" tab is selected
-            1 ->
+            1 -> ProviderPackages(provider, packages) // Display packages proposals of provider
+            2 ->
                 ProviderReviews(
                     provider, reviews) // Display ProviderReviews if "Reviews" tab is selected
           }
         }
       },
       bottomBar = { BottomBar() })
+}
+
+@Composable
+fun PackageCard(packageProposal: PackageProposal, isSelected: Boolean, modifier: Modifier) {
+  val context = LocalContext.current
+  Card(
+      modifier = modifier.fillMaxHeight(),
+      shape = RoundedCornerShape(16.dp),
+      elevation = CardDefaults.cardElevation(defaultElevation = 8.dp),
+      colors =
+          CardDefaults.cardColors(
+              containerColor =
+                  if (!isSelected) MaterialTheme.colorScheme.surface else Color(0xFF1C1651),
+          )) {
+        Column(
+            modifier = Modifier.padding(25.dp).fillMaxHeight().testTag("PackageContent"),
+            horizontalAlignment = Alignment.Start) {
+              // Price of the Package
+              Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = "$${packageProposal.price}",
+                    style =
+                        MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
+                    color = if (!isSelected) Color(0xFF231D4F) else Color.White)
+                Spacer(modifier = Modifier.width(4.dp))
+                Text(
+                    text = "/hour",
+                    style = MaterialTheme.typography.bodySmall, // Smaller style for the unit
+                    color = if (!isSelected) Color(0xFF231D4F) else Color.White)
+              }
+              // Title of the Package
+              Text(
+                  text = packageProposal.title,
+                  style = MaterialTheme.typography.titleMedium,
+                  color = if (!isSelected) Color(0xFF231D4F) else Color.White)
+              Spacer(modifier = Modifier.height(8.dp))
+              // Description of the Package
+              Text(
+                  text = packageProposal.description,
+                  style = MaterialTheme.typography.bodyMedium,
+                  color = if (!isSelected) MaterialTheme.colorScheme.onSurface else Color.White)
+              Spacer(modifier = Modifier.height(8.dp))
+              // Important infos about the package
+              Column {
+                packageProposal.bulletPoints.forEach { feature ->
+                  Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Icons.Default.CheckCircle,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(16.dp))
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Text(
+                        text = feature,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color =
+                            if (!isSelected) MaterialTheme.colorScheme.onSurface else Color.White)
+                  }
+                }
+              }
+              Spacer(modifier = Modifier.weight(1f)) // Pushes the button to the bottom
+              Button(
+                  onClick = {
+                    Toast.makeText(context, "Not implemented", Toast.LENGTH_SHORT).show()
+                  },
+                  colors =
+                      ButtonDefaults.buttonColors(
+                          containerColor =
+                              if (isSelected) Color(0xFFBB6BD9) else Color(0xFF49746F)),
+                  modifier = Modifier.align(Alignment.CenterHorizontally)) {
+                    Text("Choose plan")
+                  }
+            }
+      }
+}
+
+@Composable
+fun ProviderPackages(provider: Provider, packages: List<PackageProposal>) {
+  var selectedIndex by remember { mutableStateOf(-1) }
+  Box(
+      modifier = Modifier.fillMaxSize(), // Fills the entire available space
+      contentAlignment = Alignment.Center // Centers the LazyRow within the Box
+      ) {
+        // Horizontal scrollable list
+        LazyRow(
+            modifier = Modifier.fillMaxWidth().testTag("packagesScrollableList"),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            contentPadding = PaddingValues(top = 30.dp, start = 8.dp, end = 8.dp),
+        ) {
+          items(packages.size) { index ->
+            // If package is selected, we display it bigger
+            val isSelected = selectedIndex == index
+            val size by animateDpAsState(targetValue = if (isSelected) 335.dp else 320.dp)
+
+            PackageCard(
+                packageProposal = packages[index],
+                isSelected = isSelected,
+                modifier =
+                    Modifier.width(250.dp)
+                        .height(size)
+                        .clickable { selectedIndex = if (isSelected) -1 else index }
+                        .testTag("PackageCard"))
+          }
+        }
+      }
 }
 
 @Composable
@@ -162,6 +307,12 @@ fun ProviderTabs(selectedTabIndex: Int, onTabSelected: (Int) -> Unit) {
         Tab(
             selected = selectedTabIndex == 1,
             onClick = { onTabSelected(1) },
+            modifier = Modifier.testTag("packagesTab")) {
+              Text("Packages", modifier = Modifier.padding(16.dp))
+            }
+        Tab(
+            selected = selectedTabIndex == 2,
+            onClick = { onTabSelected(2) },
             modifier = Modifier.testTag("reviewsTab")) {
               Text("Reviews", modifier = Modifier.padding(16.dp))
             }


### PR DESCRIPTION
This PR adds a new Provider Packages Screen where users can view the different service packages offered by a provider. Each package displays details such as the price, description, and a list of features, with buttons for users to select a package or book a service.

**Details**

- Implemented a horizontally scrollable LazyRow that displays multiple package cards for a provider.
- Each package card includes:
- Price with units (e.g., "per hour"),
- Package Title and Description,
- Feature List in bullet point format,
- A "Choose plan" button for each package.

**Note :** 

Currently, the list of packages is hard-coded in the UI layer. Although the ViewModel is available, it cannot yet pull package data dynamically. This is because we do not yet have an interface that allows providers to create and manage their own service packages.

In future sprints, we plan to build this interface, which will enable providers to input their own packages directly. Once this provider interface is complete, the ViewModel will be updated to retrieve and display provider-specific packages from the backend instead of using hard-coded values.

This approach allows us to present a functional and visually accurate UI in the meantime.

**Next Steps**

- Develop and integrate a provider interface for adding and managing service packages.
- Change Colors based on the PR (Consistent Colors) but it has to be merged first


<img width="264" alt="image" src="https://github.com/user-attachments/assets/65fe5c37-1c7b-4654-a984-4886941601c9">
<img width="264" alt="image" src="https://github.com/user-attachments/assets/cf9acac4-7287-4594-9f0c-50f17e58cbb0">
