### PR TITLE
Implement notification screen

### DIFF
--- a/app/src/androidTest/java/com/android/solvit/provider/ui/NotificationScreenTest.kt
+++ b/app/src/androidTest/java/com/android/solvit/provider/ui/NotificationScreenTest.kt
@@ -1,8 +1,10 @@
 package com.android.solvit.provider.ui
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
 import androidx.navigation.NavController
 import com.android.solvit.shared.model.Notification
 import com.android.solvit.shared.model.NotificationsRepository
@@ -38,7 +40,7 @@ class NotificationsScreenTest {
           type = Services.CLEANER,
           description = "description",
           userId = "-1",
-          dueDate = Timestamp(GregorianCalendar(2024, 0, 1).time),
+          dueDate = Timestamp(GregorianCalendar(2024, 1, 1).time),
           location = Location(37.7749, -122.4194, "San Francisco"),
           imageUrl = "imageUrl",
           status = ServiceRequestStatus.PENDING)
@@ -157,5 +159,68 @@ class NotificationsScreenTest {
             eq("provider1"), // Use eq() to match the specific value
             any(), // Use matchers for the other arguments
             any())
+  }
+
+  @Test
+  fun showDialogOnNotificationClick() {
+    // Set the content of the NotificationScreen
+    composeTestRule.setContent {
+      NotificationScreen(
+          viewModel = notificationsViewModel,
+          providerId = "provider1",
+          navigationActions = navigationActions)
+    }
+
+    // Simulate a click on the first notification
+    composeTestRule.onNodeWithTag("notificationItem_1").performClick()
+
+    // Check that the dialog is displayed
+    composeTestRule.onNodeWithTag("serviceRequestDialog").assertIsDisplayed()
+
+    // Verify that the dialog displays the correct service request title, description, location, due
+    // date, and status
+    composeTestRule.onNodeWithTag("dialogTitle").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("dialogDescription").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("dialogLocation").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("dialogDueDate").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("dialogStatus").assertIsDisplayed()
+  }
+
+  @Test
+  fun dialogDisplaysCorrectServiceRequestDetails() {
+    composeTestRule.setContent {
+      NotificationScreen(
+          viewModel = notificationsViewModel,
+          providerId = "provider1",
+          navigationActions = navigationActions)
+    }
+
+    // Click on the first notification to open the dialog
+    composeTestRule.onNodeWithTag("notificationItem_1").performClick()
+
+    // Verify the service request details in the dialog
+    composeTestRule.onNodeWithTag("dialogTitle").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("dialogDescription").assertIsDisplayed()
+
+    // Verify the text content of the dialog elements matches the service request details
+    composeTestRule
+        .onNodeWithTag("dialogTitle")
+        .assertTextEquals("Title : title") // Matching the title
+    composeTestRule
+        .onNodeWithTag("dialogDescription")
+        .assertTextEquals("Description: description") // Matching the description
+
+    // For location, check if it displays correctly
+    composeTestRule.onNodeWithTag("dialogLocation").assertTextEquals("San Francisco")
+
+    // For the due date
+    composeTestRule
+        .onNodeWithTag("dialogDueDate")
+        .assertTextEquals(" 01/02/2024") // Make sure this matches the date format used
+
+    // For the status
+    composeTestRule
+        .onNodeWithTag("dialogStatus")
+        .assertTextEquals("Pending") // Ensure this matches the service request status
   }
 }

--- a/app/src/androidTest/java/com/android/solvit/provider/ui/NotificationScreenTest.kt
+++ b/app/src/androidTest/java/com/android/solvit/provider/ui/NotificationScreenTest.kt
@@ -7,8 +7,13 @@ import androidx.navigation.NavController
 import com.android.solvit.shared.model.Notification
 import com.android.solvit.shared.model.NotificationsRepository
 import com.android.solvit.shared.model.NotificationsViewModel
+import com.android.solvit.shared.model.map.Location
+import com.android.solvit.shared.model.request.ServiceRequest
+import com.android.solvit.shared.model.request.ServiceRequestStatus
+import com.android.solvit.shared.model.service.Services
 import com.android.solvit.shared.ui.navigation.NavigationActions
 import com.google.firebase.Timestamp
+import java.util.GregorianCalendar
 import junit.framework.TestCase.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -26,6 +31,18 @@ class NotificationsScreenTest {
 
   @get:Rule val composeTestRule = createComposeRule()
 
+  private val serviceRequest =
+      ServiceRequest(
+          uid = "uid",
+          title = "title",
+          type = Services.CLEANER,
+          description = "description",
+          userId = "-1",
+          dueDate = Timestamp(GregorianCalendar(2024, 0, 1).time),
+          location = Location(37.7749, -122.4194, "San Francisco"),
+          imageUrl = "imageUrl",
+          status = ServiceRequestStatus.PENDING)
+
   private val testNotifications =
       listOf(
           Notification(
@@ -34,6 +51,7 @@ class NotificationsScreenTest {
               title = "New Request",
               message = "You have a new request",
               timestamp = Timestamp.now(),
+              serviceRequest,
               isRead = false),
           Notification(
               uid = "2",
@@ -41,6 +59,7 @@ class NotificationsScreenTest {
               title = "Booking Confirmed",
               message = "Your booking is confirmed",
               timestamp = Timestamp.now(),
+              serviceRequest,
               isRead = false))
 
   @Before

--- a/app/src/main/java/com/android/solvit/MainActivity.kt
+++ b/app/src/main/java/com/android/solvit/MainActivity.kt
@@ -273,7 +273,9 @@ fun ProviderUI(
   NavHost(navController = navController, startDestination = Route.REQUESTS_FEED) {
     composable(Route.REQUESTS_FEED) {
       ListRequestsFeedScreen(
-          serviceRequestViewModel = serviceRequestViewModel, navigationActions = navigationActions)
+          serviceRequestViewModel = serviceRequestViewModel,
+          navigationActions = navigationActions,
+          notificationViewModel = notificationViewModel)
     }
     composable(Route.MAP_OF_SEEKERS) {
       ProviderMapScreen(
@@ -316,7 +318,7 @@ fun ProviderUI(
       ModifyProviderInformationScreen(
           listProviderViewModel, authViewModel, locationViewModel, navigationActions)
     }
-    composable(Route.NOTIFICATIONS) {
+    composable(Screen.NOTIFICATIONS) {
       user?.let { it1 -> NotificationScreen(notificationViewModel, it1.uid, navigationActions) }
     }
   }

--- a/app/src/main/java/com/android/solvit/provider/ui/NotificationsScreen.kt
+++ b/app/src/main/java/com/android/solvit/provider/ui/NotificationsScreen.kt
@@ -155,7 +155,7 @@ fun Dialog(onDismiss: () -> Unit, serviceRequest: ServiceRequest) {
   Dialog(onDismissRequest = onDismiss) {
     Surface(shape = RoundedCornerShape(32.dp), shadowElevation = 8.dp) {
       Column(
-          modifier = Modifier.padding(16.dp),
+          modifier = Modifier.padding(16.dp).testTag("serviceRequestDialog"),
           verticalArrangement = Arrangement.spacedBy(8.dp),
           horizontalAlignment = Alignment.CenterHorizontally) {
 
@@ -163,12 +163,13 @@ fun Dialog(onDismiss: () -> Unit, serviceRequest: ServiceRequest) {
             Text(
                 text = "Title : ${serviceRequest.title}",
                 style = MaterialTheme.typography.titleLarge,
-                color = MaterialTheme.colorScheme.primary)
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.testTag("dialogTitle"))
             // Description
             Text(
                 text = "Description: ${serviceRequest.description}",
                 style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold),
-            )
+                modifier = Modifier.testTag("dialogDescription"))
             // Location
             serviceRequest.location?.name?.let { locationName ->
               Row {
@@ -178,7 +179,8 @@ fun Dialog(onDismiss: () -> Unit, serviceRequest: ServiceRequest) {
                 Text(
                     text = locationName,
                     style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.primary // Set color for location name
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.testTag("dialogLocation") // Set color for location name
                     )
               }
             }
@@ -192,7 +194,8 @@ fun Dialog(onDismiss: () -> Unit, serviceRequest: ServiceRequest) {
                 Text(
                     text = " $formattedDate",
                     style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.primary)
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.testTag("dialogDueDate"))
               }
             }
             // Status
@@ -204,8 +207,8 @@ fun Dialog(onDismiss: () -> Unit, serviceRequest: ServiceRequest) {
                   text = ServiceRequestStatus.format(serviceRequest.status),
                   style = MaterialTheme.typography.bodyMedium,
                   color =
-                      ServiceRequestStatus.getStatusColor(serviceRequest.status) // Colored status
-                  )
+                      ServiceRequestStatus.getStatusColor(serviceRequest.status), // Colored status
+                  modifier = Modifier.testTag("dialogStatus"))
             }
           }
     }

--- a/app/src/main/java/com/android/solvit/provider/ui/NotificationsScreen.kt
+++ b/app/src/main/java/com/android/solvit/provider/ui/NotificationsScreen.kt
@@ -4,23 +4,45 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MaterialTheme.colorScheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
 import com.android.solvit.shared.model.Notification
 import com.android.solvit.shared.model.NotificationsViewModel
+import com.android.solvit.shared.model.request.ServiceRequest
+import com.android.solvit.shared.model.request.ServiceRequestStatus
 import com.android.solvit.shared.ui.navigation.NavigationActions
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NotificationScreen(
     viewModel: NotificationsViewModel,
@@ -30,32 +52,66 @@ fun NotificationScreen(
   LaunchedEffect(providerId) { viewModel.init(providerId) }
 
   val notifications by viewModel.notifications.collectAsState()
+  var showDialog by remember { mutableStateOf(false) }
+  val selectedServiceRequest = remember { mutableStateOf<ServiceRequest?>(null) }
+  Scaffold(
+      topBar = {
+        TopAppBar(
+            title = {
+              Row(
+                  modifier = Modifier.fillMaxWidth().testTag("notifications_title"),
+                  horizontalArrangement = Arrangement.Start) {
+                    Text("Notifications", textAlign = TextAlign.Center)
+                  }
+            },
+            navigationIcon = {
+              IconButton(
+                  onClick = { navigationActions.goBack() },
+                  modifier = Modifier.testTag("goBackButton")) {
+                    Icon(Icons.Filled.ArrowBack, contentDescription = "Back")
+                  }
+            })
+      }) { paddingValues ->
+        // Content inside the Scaffold
+        Column(modifier = Modifier.padding(paddingValues)) {
+          if (notifications.isEmpty()) {
+            Text(
+                text = "No notifications available",
+                modifier = Modifier.fillMaxSize().testTag("noNotificationsText"), // Added test tag
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.bodySmall)
+          } else {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize().testTag("notificationsList"), // Added test tag
+                contentPadding = PaddingValues(16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                  items(notifications) { notification ->
+                    NotificationItem(
+                        notification = notification,
+                        onClick = {
+                          showDialog = true
+                          selectedServiceRequest.value = notification.serviceRequest
+                          viewModel.markNotificationAsRead(notification)
+                        },
+                        modifier = Modifier)
+                  }
+                }
+          }
 
-  if (notifications.isEmpty()) {
-    Text(
-        text = "No notifications available",
-        modifier = Modifier.fillMaxSize().testTag("noNotificationsText"), // Added test tag
-        textAlign = TextAlign.Center,
-        style = MaterialTheme.typography.bodySmall)
-  } else {
-    LazyColumn(
-        modifier = Modifier.fillMaxSize().testTag("notificationsList"), // Added test tag
-        contentPadding = PaddingValues(16.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp)) {
-          items(notifications) { notification ->
-            NotificationItem(
-                notification = notification, onClick = {}, modifier = Modifier // Added test tag
-                )
+          // Show dialog when necessary
+          if (showDialog) {
+            Dialog(
+                onDismiss = { showDialog = false }, serviceRequest = selectedServiceRequest.value!!)
           }
         }
-  }
+      }
 }
 
 @Composable
 fun NotificationItem(
     notification: Notification,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier // Add modifier to the function
+    modifier: Modifier = Modifier
 ) {
   Card(
       modifier =
@@ -65,7 +121,8 @@ fun NotificationItem(
               .testTag("notificationItem_${notification.uid}"),
       colors =
           CardDefaults.cardColors(
-              containerColor = if (notification.isRead) Color.LightGray else Color.White),
+              containerColor =
+                  if (notification.isRead) colorScheme.surfaceVariant else colorScheme.background),
       elevation = CardDefaults.cardElevation(4.dp),
   ) {
     Column {
@@ -73,16 +130,84 @@ fun NotificationItem(
           text = notification.title,
           modifier = Modifier.testTag("notificationTitle_${notification.uid}"),
           style = MaterialTheme.typography.titleMedium,
-          color = MaterialTheme.colorScheme.primary)
+          color = colorScheme.primary,
+          textAlign = TextAlign.Center)
       Text(
           text = notification.message,
           modifier = Modifier.testTag("notificationMessage_${notification.uid}"),
           style = MaterialTheme.typography.bodyMedium)
       Text(
-          text = "Received at: ${notification.timestamp.toDate()}",
+          text = "Received on: ${notification.timestamp.toDate().formatAsDate()}",
           modifier = Modifier.testTag("notificationTimestamp_${notification.uid}"),
           style = MaterialTheme.typography.titleSmall,
           color = Color.Gray)
+    }
+  }
+}
+
+fun Date.formatAsDate(): String {
+  val sdf = SimpleDateFormat("EEE, MMM d, yyyy 'at' h:mm a", Locale.getDefault())
+  return sdf.format(this)
+}
+
+@Composable
+fun Dialog(onDismiss: () -> Unit, serviceRequest: ServiceRequest) {
+  Dialog(onDismissRequest = onDismiss) {
+    Surface(shape = RoundedCornerShape(32.dp), shadowElevation = 8.dp) {
+      Column(
+          modifier = Modifier.padding(16.dp),
+          verticalArrangement = Arrangement.spacedBy(8.dp),
+          horizontalAlignment = Alignment.CenterHorizontally) {
+
+            // Title
+            Text(
+                text = "Title : ${serviceRequest.title}",
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.primary)
+            // Description
+            Text(
+                text = "Description: ${serviceRequest.description}",
+                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold),
+            )
+            // Location
+            serviceRequest.location?.name?.let { locationName ->
+              Row {
+                Text(
+                    text = "Location: ",
+                    style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold))
+                Text(
+                    text = locationName,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.primary // Set color for location name
+                    )
+              }
+            }
+            // Due Date
+            serviceRequest.dueDate.toDate()?.let { date ->
+              val formattedDate = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault()).format(date)
+              Row {
+                Text(
+                    text = "Due Date: ",
+                    style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold))
+                Text(
+                    text = " $formattedDate",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.primary)
+              }
+            }
+            // Status
+            Row {
+              Text(
+                  text = "Status: ",
+                  style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold))
+              Text(
+                  text = ServiceRequestStatus.format(serviceRequest.status),
+                  style = MaterialTheme.typography.bodyMedium,
+                  color =
+                      ServiceRequestStatus.getStatusColor(serviceRequest.status) // Colored status
+                  )
+            }
+          }
     }
   }
 }

--- a/app/src/main/java/com/android/solvit/shared/model/Notifications.kt
+++ b/app/src/main/java/com/android/solvit/shared/model/Notifications.kt
@@ -1,5 +1,6 @@
 package com.android.solvit.shared.model
 
+import com.android.solvit.shared.model.request.ServiceRequest
 import com.google.firebase.Timestamp
 
 data class Notification(
@@ -10,7 +11,8 @@ data class Notification(
     val timestamp: Timestamp =
         Timestamp
             .now(), // The timestamp when the notification was created; defaults to current time
-    val isRead: Boolean =
+    val serviceRequest: ServiceRequest, // The related service request
+    var isRead: Boolean =
         false // Flag indicating if the notification has been read by the provider, defaults to
     // `false`
 )

--- a/app/src/main/java/com/android/solvit/shared/model/NotificationsRepository.kt
+++ b/app/src/main/java/com/android/solvit/shared/model/NotificationsRepository.kt
@@ -20,4 +20,6 @@ interface NotificationsRepository {
       onSuccess: () -> Unit,
       onFailure: (Exception) -> Unit
   )
+
+  fun updateNotificationReadStatus(notificationId: String, isRead: Boolean)
 }

--- a/app/src/main/java/com/android/solvit/shared/model/NotificationsRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/solvit/shared/model/NotificationsRepositoryFirestore.kt
@@ -1,8 +1,11 @@
 package com.android.solvit.shared.model
 
 import android.util.Log
+import com.android.solvit.shared.model.map.Location
 import com.android.solvit.shared.model.provider.Provider
 import com.android.solvit.shared.model.request.ServiceRequest
+import com.android.solvit.shared.model.request.ServiceRequestStatus
+import com.android.solvit.shared.model.service.Services
 import com.google.android.gms.tasks.Task
 import com.google.firebase.Firebase
 import com.google.firebase.Timestamp
@@ -92,6 +95,33 @@ class NotificationsRepositoryFirestore(private val db: FirebaseFirestore) :
       val message = document.getString("message") ?: return null
       val timestamp = document.getTimestamp("timestamp") ?: return null
       val isRead = document.getBoolean("isRead") ?: false
+      // Get ServiceRequest fields
+      val serviceRequestMap = document.get("serviceRequest") as? Map<String, Any> ?: return null
+      val locationMap = serviceRequestMap["location"] as? Map<String, Any>
+      val location =
+          if (locationMap != null) {
+            Location(
+                latitude = locationMap["latitude"] as? Double ?: 0.0,
+                longitude = locationMap["longitude"] as? Double ?: 0.0,
+                name = locationMap["name"] as? String ?: "")
+          } else {
+            null
+          }
+      val serviceRequest =
+          ServiceRequest(
+              uid = serviceRequestMap["uid"] as String,
+              title = serviceRequestMap["title"] as String,
+              type = Services.valueOf(serviceRequestMap["type"] as String),
+              description = serviceRequestMap["description"] as String,
+              userId = serviceRequestMap["userId"] as String,
+              providerId = serviceRequestMap["providerId"] as? String,
+              dueDate = serviceRequestMap["dueDate"] as Timestamp,
+              meetingDate = serviceRequestMap["meetingDate"] as? Timestamp,
+              location = location,
+              imageUrl = serviceRequestMap["imageUrl"] as? String,
+              packageId = serviceRequestMap["packageId"] as? String,
+              agreedPrice = serviceRequestMap["agreedPrice"] as? Double,
+              status = ServiceRequestStatus.valueOf(serviceRequestMap["status"] as String))
 
       Notification(
           uid = id,
@@ -99,6 +129,7 @@ class NotificationsRepositoryFirestore(private val db: FirebaseFirestore) :
           title = title,
           message = message,
           timestamp = timestamp,
+          serviceRequest = serviceRequest,
           isRead = isRead)
     } catch (e: Exception) {
       Log.e("NotificationsRepositoryFirestore", "Error converting document to Notification", e)
@@ -157,10 +188,11 @@ class NotificationsRepositoryFirestore(private val db: FirebaseFirestore) :
             Notification(
                 uid = getNewUid(),
                 providerId = provider.uid,
-                title = "New Service Request for ${serviceRequest.type}",
+                title = "New Service Request Available!",
                 message =
-                    "A new service request for ${serviceRequest.title} has been posted. Check it out!",
+                    "A new service request has been posted. Tap here to view the details and get started!",
                 timestamp = Timestamp.now(),
+                serviceRequest = serviceRequest,
                 isRead = false)
 
         // Save the notification for the provider
@@ -176,5 +208,21 @@ class NotificationsRepositoryFirestore(private val db: FirebaseFirestore) :
       // Notify failure in case of error
       onFailure(exception)
     }
+  }
+
+  /**
+   * Updates the read status of a notification in the Firestore database.
+   *
+   * @param notificationId The unique identifier of the notification to be updated.
+   * @param isRead The read status to set (true for read, false for unread).
+   */
+  override fun updateNotificationReadStatus(notificationId: String, isRead: Boolean) {
+    db.collection(collectionPath)
+        .document(notificationId)
+        .update("isRead", isRead)
+        .addOnSuccessListener { Log.d("NotificationsRepository", "Notification marked as read") }
+        .addOnFailureListener { e ->
+          Log.e("NotificationsRepository", "Error updating notification: $e")
+        }
   }
 }

--- a/app/src/main/java/com/android/solvit/shared/model/NotificationsViewModel.kt
+++ b/app/src/main/java/com/android/solvit/shared/model/NotificationsViewModel.kt
@@ -86,4 +86,12 @@ class NotificationsViewModel(private val repository: NotificationsRepository) : 
           Log.e("NotificationsViewModel", "Failed to send notifications: ${exception.message}")
         })
   }
+  /**
+   * Marks a notification as read by updating the `isRead` field in Firestore.
+   *
+   * @param notification The notification to be marked as read.
+   */
+  fun markNotificationAsRead(notification: Notification) {
+    repository.updateNotificationReadStatus(notification.uid, true)
+  }
 }

--- a/app/src/main/java/com/android/solvit/shared/model/request/ServiceRequest.kt
+++ b/app/src/main/java/com/android/solvit/shared/model/request/ServiceRequest.kt
@@ -12,15 +12,15 @@ import com.android.solvit.shared.ui.theme.STARTED_color
 import com.google.firebase.Timestamp
 
 data class ServiceRequest(
-    val uid: String,
-    val title: String,
-    val type: Services,
-    val description: String,
-    val userId: String,
+    val uid: String = "",
+    val title: String = "",
+    val type: Services = Services.TUTOR,
+    val description: String = "",
+    val userId: String = "",
     val providerId: String? = null,
-    val dueDate: Timestamp,
+    val dueDate: Timestamp = Timestamp.now(),
     val meetingDate: Timestamp? = null,
-    val location: Location?,
+    val location: Location? = Location(0.0, 0.0, ""),
     val imageUrl: String? = null,
     val packageId: String? = null,
     val agreedPrice: Double? = null,

--- a/app/src/main/java/com/android/solvit/shared/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/solvit/shared/ui/navigation/NavigationActions.kt
@@ -9,7 +9,6 @@ import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material.icons.outlined.LocationOn
 import androidx.compose.material.icons.outlined.MailOutline
 import androidx.compose.material.icons.outlined.Menu
-import androidx.compose.material.icons.outlined.Notifications
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.navigation.NavController
 
@@ -74,11 +73,6 @@ object TopLevelDestinations {
   val MYJOBS =
       TopLevelDestination(
           route = Route.MY_JOBS, icon = Icons.Outlined.CheckCircle, textId = "My Jobs")
-  val NOTIFICATIONS =
-      TopLevelDestination(
-          route = Route.NOTIFICATIONS,
-          icon = Icons.Outlined.Notifications,
-          textId = "Notifications")
 
   ////////////////////////////////// SEEKER //////////////////////////////////
   val SERVICES =
@@ -115,8 +109,7 @@ val LIST_TOP_LEVEL_DESTINATION_PROVIDER =
         TopLevelDestinations.MAP_OF_SEEKERS,
         TopLevelDestinations.MESSAGES,
         TopLevelDestinations.CALENDAR,
-        TopLevelDestinations.PROFESSIONAL_PROFILE,
-        TopLevelDestinations.NOTIFICATIONS)
+        TopLevelDestinations.PROFESSIONAL_PROFILE)
 
 open class NavigationActions(
     private val navController: NavController,

--- a/app/src/test/java/com/android/solvit/shared/model/provider/NotificationRepositoryTest.kt
+++ b/app/src/test/java/com/android/solvit/shared/model/provider/NotificationRepositoryTest.kt
@@ -216,4 +216,22 @@ class NotificationsRepositoryTest {
     assertEquals(Services.TUTOR, serviceRequest?.type)
     assertEquals("Need help with Math", serviceRequest?.description)
   }
+
+  /**
+   * Tests that the `updateNotificationReadStatus` function correctly updates the `isRead` field of
+   * a notification document in Firestore.
+   */
+  @Test
+  fun `updateNotificationReadStatus updates notification isRead status in Firestore`() {
+    // Arrange
+    val notificationId = "notif123" // The ID of the notification to be updated
+    val isRead = true // The new read status to set
+
+    val mockTaskCompletionSource = TaskCompletionSource<Void>()
+    `when`(mockDocumentReference.update("isRead", isRead)).thenReturn(mockTaskCompletionSource.task)
+
+    notificationsRepository.updateNotificationReadStatus(notificationId, isRead)
+    // Assert that the Firestore update method was called with the correct arguments
+    verify(mockDocumentReference).update("isRead", isRead)
+  }
 }

--- a/app/src/test/java/com/android/solvit/shared/model/provider/NotificationRepositoryTest.kt
+++ b/app/src/test/java/com/android/solvit/shared/model/provider/NotificationRepositoryTest.kt
@@ -2,6 +2,7 @@ package com.android.solvit.shared.model.provider
 
 import androidx.test.core.app.ApplicationProvider
 import com.android.solvit.shared.model.NotificationsRepositoryFirestore
+import com.android.solvit.shared.model.map.Location
 import com.android.solvit.shared.model.request.ServiceRequest
 import com.android.solvit.shared.model.service.Services
 import com.google.android.gms.tasks.TaskCompletionSource
@@ -44,7 +45,15 @@ class NotificationsRepositoryTest {
   private val notificationId = "notif123"
   private val serviceRequest =
       ServiceRequest(
-          "service123", "title", Services.TUTOR, "", "", "", Timestamp.now(), Timestamp.now(), null)
+          "service123",
+          "title",
+          Services.TUTOR,
+          "",
+          "",
+          "",
+          Timestamp.now(),
+          Timestamp.now(),
+          Location(0.0, 0.0, ""))
   private val provider = Provider("provider123", "john", Services.TUTOR)
 
   @Before
@@ -164,6 +173,7 @@ class NotificationsRepositoryTest {
   @Test
   fun `documentToNotif converts document snapshot to Notification`() {
     val mockDocumentSnapshot = mock(DocumentSnapshot::class.java)
+
     // Mock the DocumentSnapshot to return specific data
     `when`(mockDocumentSnapshot.id).thenReturn("notif123")
     `when`(mockDocumentSnapshot.getString("providerId")).thenReturn("provider123")
@@ -172,6 +182,22 @@ class NotificationsRepositoryTest {
         .thenReturn("A new service request has been posted.")
     `when`(mockDocumentSnapshot.getTimestamp("timestamp")).thenReturn(Timestamp.now())
     `when`(mockDocumentSnapshot.getBoolean("isRead")).thenReturn(false)
+
+    // Mock the serviceRequest map
+    val serviceRequestMap =
+        mapOf(
+            "uid" to "service123",
+            "title" to "Service Title",
+            "type" to "TUTOR",
+            "description" to "Need help with Math",
+            "userId" to "user123",
+            "providerId" to providerId,
+            "dueDate" to Timestamp.now(),
+            "meetingDate" to Timestamp.now(),
+            "location" to mapOf("latitude" to 10.0, "longitude" to 20.0, "name" to "New York"),
+            "status" to "PENDING")
+
+    `when`(mockDocumentSnapshot.get("serviceRequest")).thenReturn(serviceRequestMap)
 
     // Convert the document snapshot to a notification
     val notification = notificationsRepository.documentToNotif(mockDocumentSnapshot)
@@ -182,5 +208,12 @@ class NotificationsRepositoryTest {
     assertEquals("New Request", notification?.title)
     assertEquals("A new service request has been posted.", notification?.message)
     assertEquals(false, notification?.isRead)
+
+    // Also assert the serviceRequest fields
+    val serviceRequest = notification?.serviceRequest
+    assertEquals("service123", serviceRequest?.uid)
+    assertEquals("Service Title", serviceRequest?.title)
+    assertEquals(Services.TUTOR, serviceRequest?.type)
+    assertEquals("Need help with Math", serviceRequest?.description)
   }
 }

--- a/app/src/test/java/com/android/solvit/shared/model/provider/NotificationViewModelTest.kt
+++ b/app/src/test/java/com/android/solvit/shared/model/provider/NotificationViewModelTest.kt
@@ -104,6 +104,7 @@ class NotificationViewModelTest {
         title = "New Service Request",
         message = "You have a new service request for tutoring",
         timestamp = Timestamp.now(),
+        serviceRequest = serviceRequest,
         isRead = false)
   }
 

--- a/app/src/test/java/com/android/solvit/shared/model/provider/NotificationViewModelTest.kt
+++ b/app/src/test/java/com/android/solvit/shared/model/provider/NotificationViewModelTest.kt
@@ -111,4 +111,19 @@ class NotificationViewModelTest {
   private fun mockProvider(): Provider {
     return Provider(uid = "provider123", name = "John Doe", service = Services.TUTOR)
   }
+
+  /**
+   * Tests that the markNotificationAsRead function calls the repository to update the notification
+   * status correctly.
+   */
+  @Test
+  fun markNotificationAsRead_updatesNotificationReadStatus() {
+    val notification = mockNotification()
+
+    // Act: Mark the notification as read
+    notificationsViewModel.markNotificationAsRead(notification)
+
+    // Verify that the repository's updateNotificationReadStatus was called with correct parameters
+    verify(notificationsRepository).updateNotificationReadStatus(notification.uid, true)
+  }
 }


### PR DESCRIPTION
**Description:**

This PR introduces several key features and improvements to the provider notification system, alongside new tests to ensure the functionality is robust and well-tested.

**Key Changes:**
**Notification Screen Implementation:**
Added a new `NotificationScreen` where providers can view their notifications.
Each notification is displayed in a card with its title, message, and timestamp.
When a notification is clicked, a detailed dialog pops up, showing the associated service request's details (title, description, location, due date, and status).

**Modifications to**` ListRequestFeed.kt`:
In the RequestsTopBar, added an unread notification indicator that turns the notification icon red when there are unread notifications.

**Modifications to** `Notification `**Data Class:**
Updated the `Notification` data class to include a `serviceRequest` property, which holds the related ServiceRequest. This allows the display of service request details in the dialog when a notification is clicked.

**New ViewModel Function:**
Added the `markNotificationAsRead` function in the NotificationsViewModel to mark notifications as read.

**New Comprehensive UI and Unit Tests:**
**UI Tests:**
Added test tags for critical elements in the UI to verify the correct rendering of notifications and interaction with the notification dialog.

**Unit Tests:**
Added unit tests for the `NotificationsViewModel `and `NotificationsRepositoryFirestore` to verify new functionalities.

**Related Issues:**
- Fixes #199 